### PR TITLE
feat(propagate): per-consumer checkbox selection for propagating changes

### DIFF
--- a/docs/superpowers/plans/2026-05-03-per-consumer-checkbox-propagation.md
+++ b/docs/superpowers/plans/2026-05-03-per-consumer-checkbox-propagation.md
@@ -1,0 +1,548 @@
+# Per-Consumer Checkbox Propagation Prompt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the binary "Keep local / Update all" propagation prompt with a per-consumer checkbox UI so users can opt in selectively (e.g. push the new pull-up reps to Session A and Session C, but not Session B).
+
+**Depends on:** [`2026-05-03-propagation-id-stability.md`](2026-05-03-propagation-id-stability.md) — that plan stabilises ids across propagation, which is required for checkbox identity to remain meaningful between visits.
+
+**Architecture:**
+- `PropagateChangesDialog` returns a structured `PropagationSelection` instead of a `bool`. Each consumer (session or workout) is a checkbox; default state is all checked (preserves today's behaviour on a no-op confirm).
+- `PropagationSection.consumerLabels: List<String>` becomes `consumers: List<PropagationConsumer>` with stable ids.
+- `propagateBag(bag, selection: ...)` plumbs the selection to each `propagate*` function, which accepts an optional `Set<String>` filter on consumer ids.
+- Selection-map keys are kind-prefixed (`workout-in-sessions:<id>`, `exercise-in-sessions:<id>`, `exercise-in-workouts:<id>`) so an exercise that has both session-template consumers and workout consumers can be tracked separately.
+
+**Tech Stack:** Flutter (Dart), Provider, flutter_test
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|--------|------|--------------|
+| Modify | `lib/presentation/widgets/propagate_changes_dialog.dart` | Add `PropagationConsumer`, `PropagationSelection`; render checkboxes; return selection |
+| Modify | `lib/providers/preset_provider.dart` | `propagate*` functions accept `Set<String>?` filter; `propagateBag` accepts `PropagationSelection?` |
+| Modify | `lib/presentation/screens/training_program_flow/new_workout_screen.dart` | Build `PropagationConsumer` lists with stable ids; pass selection to `propagateBag` |
+| Modify | `lib/presentation/screens/training_program_flow/new_exercise_screen.dart` | Same |
+| Modify | `lib/presentation/screens/training_program_flow/new_session_screen.dart` | Same |
+| Test | `test/widgets/propagate_changes_dialog_test.dart` | New — widget tests for checkbox UI |
+| Test | `test/providers/preset_provider_propagate_test.dart` | New tests for partial selection |
+
+---
+
+## Selection-key convention
+
+Sections in the dialog can describe three categories of consumer:
+
+| Section's `itemKind` | Consumer kind | Selection key |
+|----------------------|---------------|---------------|
+| `'workout'` | sessions | `'workout-in-sessions:<workoutId>'` |
+| `'exercise'` (when listed under sessions in the prompt) | sessions | `'exercise-in-sessions:<exerciseId>'` |
+| `'exercise'` (when listed under workouts in the prompt) | workouts | `'exercise-in-workouts:<exerciseId>'` |
+
+Two `PropagationSection`s can share the same `itemId` (same exercise, two consumer categories). The kind-prefixed key disambiguates them.
+
+---
+
+## Task List Overview
+
+### Phase 1 — Dialog and selection model
+- [ ] Task 1: Define `PropagationConsumer` + `PropagationSelection` and update `PropagationSection`
+- [ ] Task 2: Render checkboxes; return selection on confirm + widget tests
+
+### Phase 2 — Provider plumbing
+- [ ] Task 3: `propagate*` functions accept `Set<String>?` filter + tests
+- [ ] Task 4: `propagateBag` accepts `PropagationSelection?` + tests
+
+### Phase 3 — Edit screens
+- [ ] Task 5: `NewWorkoutScreen` builds consumers with ids; passes selection
+- [ ] Task 6: `NewExerciseScreen` same
+- [ ] Task 7: `NewSessionScreen` same
+
+### Phase 4 — Verification
+- [ ] Task 8: Manual end-to-end repro
+- [ ] Task 9: `flutter analyze` clean and `flutter test` green
+
+---
+
+## Phase 1 — Dialog and selection model
+
+### Task 1: Define `PropagationConsumer` + `PropagationSelection` and update `PropagationSection`
+
+**Files:**
+- Modify: `lib/presentation/widgets/propagate_changes_dialog.dart`
+
+**Why:** The current dialog API takes opaque consumer label strings, so it has no way to identify which consumers the user kept vs. dropped. Promote labels to objects with stable ids.
+
+- [ ] **Step 1: Add types**
+
+```dart
+class PropagationConsumer {
+  /// Stable id of the consumer (session id or workout id, depending on
+  /// the section's itemKind / consumer kind).
+  final String id;
+  /// Display title shown next to the checkbox.
+  final String label;
+
+  const PropagationConsumer({required this.id, required this.label});
+}
+
+class PropagationSection {
+  PropagationSection({
+    required this.itemKind,
+    required this.itemId,
+    required this.itemTitle,
+    required this.consumers,
+    required this.consumerKind, // 'sessions' | 'workouts'
+  });
+
+  /// 'workout' or 'exercise' — what is being changed.
+  final String itemKind;
+  /// Stable id of the changed item.
+  final String itemId;
+  /// Display title of the changed item.
+  final String itemTitle;
+  /// What kind of consumer this section lists.
+  final String consumerKind;
+  final List<PropagationConsumer> consumers;
+
+  /// Selection-map key. See plan documentation for convention.
+  String get selectionKey => '$itemKind-in-$consumerKind:$itemId';
+}
+
+class PropagationSelection {
+  /// Keyed by `PropagationSection.selectionKey` → set of consumer ids the
+  /// user chose to update. Sections not present default to "none selected".
+  PropagationSelection(this._byKey);
+  final Map<String, Set<String>> _byKey;
+
+  Set<String> consumerIdsFor(PropagationSection section) =>
+      _byKey[section.selectionKey] ?? const {};
+
+  bool get isEmpty => _byKey.values.every((s) => s.isEmpty);
+
+  /// Convenience for callers building a "by item id" lookup. Filters to
+  /// only the requested consumer kind so a single id with both consumer
+  /// categories doesn't clash.
+  Set<String>? sessionIdsFor(String itemKind, String itemId) =>
+      _byKey['$itemKind-in-sessions:$itemId'];
+  Set<String>? workoutIdsFor(String itemKind, String itemId) =>
+      _byKey['$itemKind-in-workouts:$itemId'];
+}
+```
+
+- [ ] **Step 2: Update existing dialog signature** to take the new section shape (UI rendering happens in Task 2). Old callers will break — that's fine; Tasks 5–7 update them.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(propagate-dialog): introduce PropagationConsumer and PropagationSelection"
+```
+
+---
+
+### Task 2: Render checkboxes; return selection + widget tests
+
+**Files:**
+- Modify: `lib/presentation/widgets/propagate_changes_dialog.dart`
+- Test: `test/widgets/propagate_changes_dialog_test.dart` (CREATE)
+
+- [ ] **Step 1: Failing widget test**
+
+```dart
+testWidgets('all consumers checked by default; Update returns full selection',
+    (tester) async {
+  final sections = [
+    PropagationSection(
+      itemKind: 'workout',
+      itemId: 'cat-w',
+      itemTitle: 'Climbing Warm-up',
+      consumerKind: 'sessions',
+      consumers: [
+        PropagationConsumer(id: 's-a', label: 'Session A'),
+        PropagationConsumer(id: 's-b', label: 'Session B'),
+      ],
+    ),
+  ];
+  PropagationSelection? result;
+  await tester.pumpWidget(MaterialApp(home: Builder(builder: (ctx) {
+    return ElevatedButton(
+      onPressed: () async {
+        result = await showPropagateChangesDialog(
+            context: ctx, sections: sections);
+      },
+      child: const Text('open'),
+    );
+  })));
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+
+  await tester.tap(find.text('Update selected'));
+  await tester.pumpAndSettle();
+
+  expect(result, isNotNull);
+  expect(result!.consumerIdsFor(sections.first), {'s-a', 's-b'});
+});
+
+testWidgets('unchecking removes the consumer from the selection',
+    (tester) async {
+  // ...similar setup, untap the checkbox for Session B before Update...
+  expect(result!.consumerIdsFor(sections.first), {'s-a'});
+});
+
+testWidgets('Cancel returns null', (tester) async {
+  // ...tap Cancel...
+  expect(result, isNull);
+});
+```
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```dart
+Future<PropagationSelection?> showPropagateChangesDialog({
+  required BuildContext context,
+  required List<PropagationSection> sections,
+}) {
+  // Initialise selection with all consumers checked (preserves
+  // back-compat behaviour for users who just confirm without changing
+  // anything).
+  final selected = <String, Set<String>>{
+    for (final s in sections)
+      s.selectionKey: {for (final c in s.consumers) c.id},
+  };
+  return showDialog<PropagationSelection>(
+    context: context,
+    builder: (ctx) => StatefulBuilder(builder: (ctx, setState) {
+      return AlertDialog(
+        title: const Text('Apply changes elsewhere?'),
+        content: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (var i = 0; i < sections.length; i++) ...[
+                if (i > 0) ...const [
+                  SizedBox(height: 12),
+                  Divider(height: 1),
+                  SizedBox(height: 12),
+                ],
+                Text(
+                  '${sections[i].itemTitle} (${sections[i].itemKind}) '
+                  'is also used in:',
+                ),
+                ...sections[i].consumers.map((c) {
+                  final key = sections[i].selectionKey;
+                  final isChecked = selected[key]!.contains(c.id);
+                  return CheckboxListTile(
+                    value: isChecked,
+                    title: Text(c.label),
+                    onChanged: (v) => setState(() {
+                      if (v == true) {
+                        selected[key]!.add(c.id);
+                      } else {
+                        selected[key]!.remove(c.id);
+                      }
+                    }),
+                  );
+                }),
+                Row(children: [
+                  TextButton(
+                    onPressed: () => setState(() {
+                      selected[sections[i].selectionKey] = {
+                        for (final c in sections[i].consumers) c.id,
+                      };
+                    }),
+                    child: const Text('Select all'),
+                  ),
+                  TextButton(
+                    onPressed: () => setState(() {
+                      selected[sections[i].selectionKey]!.clear();
+                    }),
+                    child: const Text('Select none'),
+                  ),
+                ]),
+              ],
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx)
+                .pop(PropagationSelection(Map.of(selected))),
+            child: const Text('Update selected'),
+          ),
+        ],
+      );
+    }),
+  );
+}
+```
+
+- [ ] **Step 4: Run** — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(propagate-dialog): per-consumer checkboxes with selection result"
+```
+
+---
+
+## Phase 2 — Provider plumbing
+
+### Task 3: `propagate*` functions accept `Set<String>?` filter
+
+**Files:**
+- Modify: `lib/providers/preset_provider.dart`
+- Test: `test/providers/preset_provider_propagate_test.dart`
+
+**Why:** Each propagation function currently iterates every match. To honour user selection, accept an optional filter on consumer ids; `null` means "all" (preserves callers that don't filter).
+
+- [ ] **Step 1: Failing test**
+
+```dart
+test('propagateWorkoutToSessionTemplates with onlyToSessionIds filters', () async {
+  // Three sessions A, B, C all reference catalog workout 'cat-w'.
+  // Filter to {A.id, C.id}. After: A and C updated, B unchanged.
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```dart
+Future<void> propagateWorkoutToSessionTemplates(
+  Workout updated, {
+  Set<String>? onlyToSessionIds,
+}) async {
+  final affected = usagesOfWorkout(updated.id)
+      .where((s) => onlyToSessionIds == null || onlyToSessionIds.contains(s.id))
+      .toList();
+  for (final session in affected) {
+    final newWorkouts = session.workouts.map((w) {
+      if (w.id == updated.id || w.templateId == updated.id) {
+        return updated.deepCopy(keepId: true);
+      }
+      return w;
+    }).toList();
+    await promoteAndUpdateSession(session.copyWith(workouts: newWorkouts));
+  }
+}
+
+Future<void> propagateExerciseToSessionTemplates(
+  Exercise updated, {
+  Set<String>? onlyToSessionIds,
+}) async {
+  // mirror — filter sessions before walking
+}
+
+Future<void> propagateExerciseToWorkouts(
+  Exercise updated, {
+  Set<String>? onlyToWorkoutIds,
+}) async {
+  // mirror — filter workouts before replacing
+}
+```
+
+- [ ] **Step 3: Run; commit**
+
+```bash
+git commit -m "feat(preset): propagate functions accept consumer-id filters"
+```
+
+---
+
+### Task 4: `propagateBag` accepts `PropagationSelection?`
+
+**Files:**
+- Modify: `lib/providers/preset_provider.dart`
+- Test: `test/providers/preset_provider_propagate_test.dart`
+
+- [ ] **Step 1: Failing tests**
+
+```dart
+test('propagateBag with empty selection writes nothing', () async {
+  // Bag with one bagged exercise + selection that has no consumers checked.
+  // Affected sessions/workouts unchanged after call.
+});
+
+test('propagateBag with partial selection only updates chosen consumers',
+    () async {
+  // Three sibling sessions; selection contains only two of them.
+  // Two updated; third unchanged.
+});
+
+test('propagateBag with null selection updates all (back-compat guard)',
+    () async {
+  // Bag without selection arg. All consumers updated. (Same behaviour as
+  // before this plan landed.)
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```dart
+Future<void> propagateBag(
+  PendingChangeBag bag, {
+  PropagationSelection? selection,
+}) async {
+  for (final ec in bag.exercisesById.values) {
+    await propagateExerciseToSessionTemplates(
+      ec.exercise,
+      onlyToSessionIds:
+          selection?.sessionIdsFor('exercise', ec.exercise.id),
+    );
+    await propagateExerciseToWorkouts(
+      ec.exercise,
+      onlyToWorkoutIds:
+          selection?.workoutIdsFor('exercise', ec.exercise.id),
+    );
+  }
+  for (final wc in bag.workoutsById.values) {
+    await propagateWorkoutToSessionTemplates(
+      wc.workout,
+      onlyToSessionIds:
+          selection?.sessionIdsFor('workout', wc.workout.id),
+    );
+  }
+}
+```
+
+- [ ] **Step 3: Run; commit**
+
+```bash
+git commit -m "feat(preset): propagateBag accepts PropagationSelection"
+```
+
+---
+
+## Phase 3 — Edit screens
+
+### Task 5: `NewWorkoutScreen` builds consumers with ids; passes selection
+
+**Files:**
+- Modify: `lib/presentation/screens/training_program_flow/new_workout_screen.dart`
+
+- [ ] **Step 1: Build sections with `PropagationConsumer`**
+
+Replace the existing section-build with:
+
+```dart
+final sections = <PropagationSection>[
+  for (final entry in result.affectedSessionsByWorkoutId.entries)
+    PropagationSection(
+      itemKind: 'workout',
+      itemId: entry.key,
+      itemTitle: workout.title,
+      consumerKind: 'sessions',
+      consumers: [
+        for (final s in entry.value)
+          PropagationConsumer(id: s.id, label: s.title),
+      ],
+    ),
+  for (final entry in result.affectedWorkoutsByExerciseId.entries)
+    PropagationSection(
+      itemKind: 'exercise',
+      itemId: entry.key,
+      itemTitle: bag.exercisesById[entry.key]!.exercise.title,
+      consumerKind: 'workouts',
+      consumers: [
+        for (final w in entry.value)
+          PropagationConsumer(id: w.id, label: w.title),
+      ],
+    ),
+];
+
+final selection = await showPropagateChangesDialog(
+  context: context,
+  sections: sections,
+);
+if (selection != null && !selection.isEmpty) {
+  await presetProvider.propagateBag(bag, selection: selection);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "feat(workout-edit): pass per-consumer selection to propagateBag"
+```
+
+---
+
+### Task 6: `NewExerciseScreen` same shape
+
+**Files:**
+- Modify: `lib/presentation/screens/training_program_flow/new_exercise_screen.dart`
+
+Mirror Task 5: build sections with `PropagationConsumer`, pass selection.
+
+- [ ] **Step 1: Update; commit**
+
+```bash
+git commit -m "feat(exercise-edit): pass per-consumer selection to propagateBag"
+```
+
+---
+
+### Task 7: `NewSessionScreen` same shape
+
+**Files:**
+- Modify: `lib/presentation/screens/training_program_flow/new_session_screen.dart`
+
+Mirror Task 5.
+
+- [ ] **Step 1: Update; commit**
+
+```bash
+git commit -m "feat(session-edit): pass per-consumer selection to propagateBag"
+```
+
+---
+
+## Phase 4 — Verification
+
+### Task 8: Manual end-to-end repro
+
+- [ ] **Step 1: Partial selection.**
+  1. Open the catalog Workouts tab → tap a workout used in three sessions → edit something → save.
+  2. Prompt fires with three checkboxes, all checked.
+  3. Uncheck one → tap Update selected.
+  4. Verify the unchecked session retains the previous content; the others updated.
+
+- [ ] **Step 2: Repeat-prompt for the unchecked one.**
+  1. Edit the same workout again from inside the previously-unchecked session.
+  2. The prompt fires again listing the other two sessions (since they share the catalog id; lookup still finds them).
+
+- [ ] **Step 3: Cancel keeps everything local.**
+  1. Edit a workout → on the prompt, tap Cancel.
+  2. Other consumers untouched. Catalog item updated.
+
+- [ ] **Step 4: Empty selection acts like cancel.**
+  1. Edit a workout → uncheck everything → tap Update selected.
+  2. Other consumers untouched. Catalog item still updated.
+
+- [ ] **Step 5: Mixed sections (workout + exercise).**
+  1. Set up: a session with a workout containing pull-ups, and another workout in the catalog also containing pull-ups.
+  2. Edit pull-ups via the session's drilldown so the bag has both a session-embedded workout change and a session-embedded exercise change… *(if the suppression rule from the unified-edit plan kicks in, exercise-level section may not appear; that's expected)*. Adjust the scenario to one that does generate two sections.
+  3. Confirm both sections each have their own checkboxes; selection on one does not affect the other.
+
+---
+
+### Task 9: `flutter analyze` clean and `flutter test` green
+
+- [ ] `flutter analyze` — no new warnings.
+- [ ] `flutter test` — all tests pass.
+
+---
+
+## Out of scope (call out for future plans)
+
+- **Persisting selection state across edits** ("don't ask me about Session B again"). Could be a per-session preference or a per-template-per-consumer ignore list.
+- **Per-consumer change preview.** Today the prompt only shows titles; a future feature could show a diff or a summary of what's about to change for each consumer.
+- **Bulk-selection helpers across sections.** Right now each section has its own Select all / Select none. A "Select none across all sections" might be useful with many sections.

--- a/docs/superpowers/plans/2026-05-03-propagation-id-stability.md
+++ b/docs/superpowers/plans/2026-05-03-propagation-id-stability.md
@@ -1,0 +1,433 @@
+# Propagation ID Stability and Session-Scoped Commit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Editing a session-embedded workout/exercise should (1) find all sibling sessions for the propagation prompt regardless of how many propagations have already happened, and (2) never silently create a duplicate catalog entry.
+
+**Background — two bugs:**
+
+1. **Lookup misses templateId siblings.** After a Yes-to-propagate, `propagateWorkoutToSessionTemplates` writes a `Workout.deepCopy()` (no `keepId`) into each affected session. Each embedded copy gets a fresh UUID; only `templateId` links back to the catalog. On a second edit of any embedded copy, `usagesOfWorkout(<fresh-uuid>)` finds no other sessions sharing that fresh id, so the prompt does not fire and propagation cannot run.
+
+2. **Session-embedded workouts are silently promoted.** `commitChanges` calls `promoteAndUpdateWorkout`/`promoteAndUpdateExercise` for every item in the bag. For a session-screen save the bag contains the session's embedded workouts and exercises (which have fresh UUIDs from the deep-copy above). They are appended to `_userWorkouts`/`_userExercises` as new catalog entries — duplicates with the catalog originals.
+
+**Resolution:** Treat `id` as the stable identity of a template. Embedded copies in sessions retain the catalog id; deep-copies for propagation/embedding default to `keepId: true`. Slidable Copy stays on `deepCopy()` with a fresh UUID (intentional fork). `commitChanges` becomes session-scope-aware: when the bag has a session, the bagged workouts/exercises are session-embedded and are NOT pushed to the catalog.
+
+**Tech Stack:** Flutter (Dart), Provider, flutter_test
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|--------|------|--------------|
+| Modify | `lib/models/workout.dart` | Doc-comment update on `deepCopy({keepId})` |
+| Modify | `lib/models/exercise.dart` | Doc-comment update on `deepCopy({keepId})` |
+| Modify | `lib/models/session.dart` | Doc-comment update on `deepCopy({keepId})` |
+| Modify | `lib/providers/preset_provider.dart` | `propagate*` functions use `keepId: true`; `commitChanges` skips catalog promotion when `bag.session != null` |
+| Modify | `lib/presentation/screens/training_program_flow/add_item_screen.dart` | On-add `deepCopy()` → `deepCopy(keepId: true)` |
+| Modify | `lib/presentation/screens/training_program_flow/new_session_screen.dart` | Comment-only on `_copyWorkout` |
+| Modify | `lib/presentation/screens/training_program_flow/new_workout_screen.dart` | Comment-only on `_copyExercise` |
+| Test | `test/providers/preset_provider_propagate_test.dart` | New tests for id stability + second-pass edit |
+| Test | `test/providers/preset_provider_commit_changes_test.dart` | New tests for session-scoped commit not promoting |
+
+---
+
+## Data invariants
+
+1. **`id` is the stable logical identity of a template.** A catalog workout, every session-embedded copy of it, and every propagated-into-sibling copy all share the same `id`. The `id` answers "which template is this?".
+
+2. **`templateId` is a soft breadcrumb.** Set by `deepCopy(keepId: false)` to point at the source's id. Used today only to support legacy data and a possible future "this used to be a fork of X" feature. Not used for propagation lookup once this plan ships, because the stable `id` covers that case.
+
+3. **Object identity ≠ id identity.** Two sessions referencing the same template each hold their own Dart `Workout` instance (independent in memory, deep-copied) but share the catalog id. Mutating one cannot leak into the other (deep-copy guarantee), but propagation can find both (id-match guarantee).
+
+4. **`_pending.workoutsById` "last edit wins per session" is unchanged.** Within a single session edit, if the same workout id appears twice (e.g. user added the same template as two cards for circuits) and the user edits one of them, the bag holds the latest edit under that id. The session's `setSession(...)` carries both occurrences inline; the propagation logic targets the catalog id and updates other sessions accordingly.
+
+5. **Slidable Copy means divergence.** `_copyWorkout` and `_copyExercise` keep generating fresh UUIDs. Two cards in the same session that came from a Copy are independent and do not propagate to each other.
+
+6. **Session-start (logging) is unchanged.** Starting a session run still calls `Session.deepCopy(keepId: false)` so the run record gets a fresh id distinct from the template.
+
+---
+
+## Task List Overview
+
+### Phase 1 — Update propagation and embedding to keep ids
+- [ ] Task 1: `propagateWorkoutToSessionTemplates` uses `keepId: true` + tests
+- [ ] Task 2: `propagateExerciseToSessionTemplates` uses `keepId: true` + tests
+- [ ] Task 3: `propagateExerciseToWorkouts` uses `keepId: true` + tests
+- [ ] Task 4: `AddItemScreen` returns `deepCopy(keepId: true)` + manual repro
+
+### Phase 2 — Session-scoped `commitChanges`
+- [ ] Task 5: `commitChanges` skips catalog promotion when `bag.session != null` + tests
+- [ ] Task 6: Adjust existing tests that assumed unconditional promotion
+
+### Phase 3 — Documentation and intent comments
+- [ ] Task 7: Update `Workout`/`Exercise`/`Session` `deepCopy` doc-comments
+- [ ] Task 8: Annotate `_copyWorkout`/`_copyExercise` with intent
+
+### Phase 4 — End-to-end verification and cleanup
+- [ ] Task 9: Manual repro of the original bug scenarios
+- [ ] Task 10: `flutter analyze` clean and `flutter test` green
+
+---
+
+## Phase 1 — Update propagation and embedding to keep ids
+
+### Task 1: `propagateWorkoutToSessionTemplates` uses `keepId: true`
+
+**Files:**
+- Modify: `lib/providers/preset_provider.dart`
+- Test: `test/providers/preset_provider_propagate_test.dart`
+
+**Why:** After propagation, sibling sessions must be discoverable by `usagesOfWorkout(catalogId)`. Today the propagation rewrites embedded copies with fresh UUIDs, so the lookup misses them on the next edit.
+
+- [ ] **Step 1: Failing test**
+
+In `propagateWorkoutToSessionTemplates` group:
+
+```dart
+test('embedded copies retain the catalog id after propagation', () async {
+  final ex = _exercise(id: 'cat-e', sets: 3);
+  final catalogW = _workout(id: 'cat-w', exercises: [ex]);
+  final embeddedA = _workout(id: 'cat-w', exercises: [ex.deepCopy(keepId: true)]);
+  final embeddedB = _workout(id: 'cat-w', exercises: [ex.deepCopy(keepId: true)]);
+  final sA = _session(id: 's-a', workouts: [embeddedA]);
+  final sB = _session(id: 's-b', workouts: [embeddedB]);
+  provider.debugSeedDefaults(workouts: [catalogW], sessions: [sA, sB]);
+
+  final updated = catalogW.copyWith(timeBetweenExercises: 999);
+  await provider.propagateWorkoutToSessionTemplates(updated);
+
+  for (final session in provider.presetSessions) {
+    for (final w in session.workouts) {
+      expect(w.id, 'cat-w', reason: 'id must remain catalog id after propagation');
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```dart
+Future<void> propagateWorkoutToSessionTemplates(Workout updated) async {
+  final affected = usagesOfWorkout(updated.id);
+  for (final session in affected) {
+    final newWorkouts = session.workouts.map((w) {
+      if (w.id == updated.id || w.templateId == updated.id) {
+        return updated.deepCopy(keepId: true);
+      }
+      return w;
+    }).toList();
+    await promoteAndUpdateSession(session.copyWith(workouts: newWorkouts));
+  }
+}
+```
+
+- [ ] **Step 4: Run** — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "fix(propagate): keep catalog id when propagating workout edits"
+```
+
+---
+
+### Task 2: `propagateExerciseToSessionTemplates` uses `keepId: true`
+
+**Files:**
+- Modify: `lib/providers/preset_provider.dart`
+- Test: `test/providers/preset_provider_propagate_test.dart`
+
+- [ ] **Step 1: Failing test** — mirror Task 1 for exercise: after propagation, every embedded exercise has `id == updated.id`.
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement** — change the inner exercise replacement:
+
+```dart
+final newExercises = w.exercises.map((e) {
+  if (e.id == updated.id || e.templateId == updated.id) {
+    return updated.deepCopy(keepId: true);
+  }
+  return e;
+}).toList();
+```
+
+- [ ] **Step 4: Run** — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "fix(propagate): keep catalog id when propagating exercise edits to sessions"
+```
+
+---
+
+### Task 3: `propagateExerciseToWorkouts` uses `keepId: true`
+
+**Files:**
+- Modify: `lib/providers/preset_provider.dart`
+- Test: `test/providers/preset_provider_propagate_test.dart`
+
+- [ ] **Step 1: Failing test** — propagate an exercise edit; assert each affected workout's matching exercise retains `id == updated.id`.
+
+- [ ] **Step 2: Implement**
+
+```dart
+final newExercises = workout.exercises.map((e) {
+  if (e.id == updated.id || e.templateId == updated.id) {
+    return updated.deepCopy(keepId: true);
+  }
+  return e;
+}).toList();
+```
+
+- [ ] **Step 3: Run; commit**
+
+```bash
+git commit -m "fix(propagate): keep catalog id when propagating exercise edits to workouts"
+```
+
+---
+
+### Task 4: `AddItemScreen` returns `deepCopy(keepId: true)`
+
+**Files:**
+- Modify: `lib/presentation/screens/training_program_flow/add_item_screen.dart`
+
+**Why:** When a catalog item is added to a session for the first time, the embedded copy's id should match the catalog id so the very first edit (or the first propagation) can find siblings.
+
+- [ ] **Step 1: Replace the on-pop deep-copy**
+
+```dart
+final independent = selectedPresetItems.map((item) {
+  if (item is Workout) return item.deepCopy(keepId: true);
+  if (item is Exercise) return item.deepCopy(keepId: true);
+  return item;
+}).toList();
+Navigator.pop(context, independent);
+```
+
+- [ ] **Step 2: Manual repro**: New session → add a default workout → save → catalog → edit that workout → save → propagation prompt fires listing the new session.
+
+- [ ] **Step 3: Run tests; commit**
+
+```bash
+git commit -m "fix(add-item): preserve catalog id on add so first-edit propagation works"
+```
+
+---
+
+## Phase 2 — Session-scoped `commitChanges`
+
+### Task 5: `commitChanges` skips catalog promotion when `bag.session != null`
+
+**Files:**
+- Modify: `lib/providers/preset_provider.dart`
+- Test: `test/providers/preset_provider_commit_changes_test.dart`
+
+**Why:** A session-screen save passes a bag containing the session and its session-embedded workouts/exercises. Those embedded items must NOT become standalone catalog rows. They live inside the session JSON and are persisted by the session's own promote.
+
+- [ ] **Step 1: Failing tests**
+
+```dart
+test('session-scoped commit does not promote workouts to catalog', () async {
+  final ex = _exercise(id: 'cat-e');
+  final catalogW = _workout(id: 'cat-w', exercises: [ex]);
+  final sa = _session(id: 'cat-s', workouts: [catalogW]);
+  provider.debugSeedDefaults(workouts: [catalogW], sessions: [sa]);
+
+  final embeddedW = catalogW.copyWith(timeBetweenExercises: 999);
+  final bag = PendingChangeBag()
+    ..setSession(sa.copyWith(workouts: [embeddedW]))
+    ..addWorkout(embeddedW);
+
+  final beforeUserWorkouts = provider.presetUserWorkoutsIDs.length;
+  await provider.commitChanges(bag);
+
+  expect(provider.presetUserWorkoutsIDs.length, beforeUserWorkouts);
+});
+
+test('session-scoped commit does not promote exercises to catalog', () async {
+  // mirror the workout test for exercises
+});
+
+test('catalog-scoped commit still promotes (regression guard)', () async {
+  final w = _workout(id: 'cat-w', exercises: []);
+  provider.debugSeedDefaults(workouts: [w]);
+  final bag = PendingChangeBag()..addWorkout(w.copyWith(timeBetweenExercises: 999));
+  await provider.commitChanges(bag);
+  expect(provider.presetUserWorkoutsIDs, contains('cat-w'));
+});
+```
+
+- [ ] **Step 2: Run** — first two FAIL, third PASS (existing behaviour).
+
+- [ ] **Step 3: Implement**
+
+```dart
+Future<CommitResult> commitChanges(
+  PendingChangeBag bag, {
+  String? excludeSessionId,
+  String? excludeWorkoutId,
+}) async {
+  final isSessionScopedCommit = bag.session != null;
+
+  if (!isSessionScopedCommit) {
+    for (final ec in bag.exercisesById.values) {
+      await promoteAndUpdateExercise(ec.exercise);
+    }
+    for (final wc in bag.workoutsById.values) {
+      await promoteAndUpdateWorkout(wc.workout);
+    }
+  }
+  if (bag.session != null) {
+    await promoteAndUpdateSession(bag.session!.session);
+  }
+
+  // ── affected-consumer computation unchanged ──────────────────────────────
+  // (existing sessionsByWorkout / workoutsByExercise logic stays as-is)
+  // ...
+}
+```
+
+- [ ] **Step 4: Run** — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "fix(preset): commitChanges skips catalog promotion for session-scoped bags"
+```
+
+---
+
+### Task 6: Adjust existing commit-changes tests
+
+**Files:**
+- Modify: `test/providers/preset_provider_commit_changes_test.dart`
+
+**Why:** The test "promotes in dependency order: exercises before workouts before session" asserts all three lists grow together. Under the new model, a session-scoped bag only grows `_userSessions`. Split or update.
+
+- [ ] **Step 1:** Audit the existing tests in this file. For each test that builds a session-scoped bag (i.e. calls `bag.setSession(...)`):
+  - If it asserts `_userWorkouts`/`_userExercises` membership after commit, update the assertion to confirm those lists are unchanged.
+  - If it asserts dependency-ordering, split into two tests: one for catalog-scoped (workouts and exercises promoted), one for session-scoped (only session promoted; bagged workouts/exercises are not in `_user*`).
+
+- [ ] **Step 2: Run; commit**
+
+```bash
+git commit -m "test(preset): adjust commit-changes tests for session-scope semantics"
+```
+
+---
+
+## Phase 3 — Documentation and intent comments
+
+### Task 7: Update `deepCopy` doc-comments
+
+**Files:**
+- Modify: `lib/models/workout.dart`, `lib/models/exercise.dart`, `lib/models/session.dart`
+
+- [ ] **Step 1: Replace the `deepCopy` doc-comment** with:
+
+```dart
+/// Creates an independent Dart copy with deep-copied children.
+///
+/// With [keepId] = true (default for propagation, AddItemScreen, and any
+/// "this is the same logical template, just a separate instance" use case):
+/// the copy keeps the source's id and templateId. Mutating one instance
+/// cannot leak into another (deep-copy guarantee), but propagation lookups
+/// (`usagesOfWorkout`/`usagesOfExercise`) match by id and so naturally
+/// find every sibling instance.
+///
+/// With [keepId] = false: generates a fresh UUID and sets templateId as a
+/// breadcrumb pointing at the source's id. Use only for genuine forks:
+/// slidable Copy (intentional divergence — the user wants to evolve the
+/// copy independently of the original) and starting a session run (the
+/// run record is its own entity, not a template).
+```
+
+(Adjust per model — the `Workout` version mentions exercises, the `Session` version mentions workouts.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "docs(models): clarify keepId semantics on deepCopy"
+```
+
+---
+
+### Task 8: Annotate `_copyWorkout`/`_copyExercise` with intent
+
+**Files:**
+- Modify: `lib/presentation/screens/training_program_flow/new_session_screen.dart`
+- Modify: `lib/presentation/screens/training_program_flow/new_workout_screen.dart`
+
+**Why:** A future reader looking at `workout.deepCopy()` (no `keepId`) might think it's stale. Make the intent explicit so they don't "fix" it.
+
+- [ ] **Step 1: Add a one-liner above each Copy method**:
+
+```dart
+// Slidable Copy means divergence. Fresh UUID so this card evolves
+// independently of the original (e.g. a circuits use case where the same
+// template appears twice with different reps/loads).
+_copyWorkout(Workout workout) {
+  final newWorkout = workout.deepCopy();
+  ...
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "docs(edit-screens): explain why slidable Copy uses fresh UUIDs"
+```
+
+---
+
+## Phase 4 — End-to-end verification and cleanup
+
+### Task 9: Manual repro
+
+Run through these scenarios on a real device or simulator:
+
+- [ ] **Step 1: First-pass propagation (regression guard).**
+  1. Two default sessions both contain Climbing Warm-up.
+  2. Open Session A → drill into Climbing Warm-up → change an exercise's reps → save the session.
+  3. Combined prompt fires listing Session B as affected. Tap **Update all**.
+  4. Open Session B — embedded Climbing Warm-up shows the new reps.
+
+- [ ] **Step 2: Second-pass propagation (the bug this plan fixes).**
+  1. Open Session B (just updated above) → drill into Climbing Warm-up → change a different exercise's reps → save the session.
+  2. **Combined prompt fires** listing the other sessions (A, plus any others).
+  3. Tap **Update all** → all of them update.
+
+- [ ] **Step 3: No catalog duplicates.**
+  1. After running steps 1–2, open the Workouts tab in the catalog.
+  2. **Climbing Warm-up appears exactly once.** No duplicate user-list entry.
+
+- [ ] **Step 4: Slidable Copy still creates a fork.**
+  1. Inside a session edit, slidable-Copy a workout.
+  2. The copy gets a fresh UUID (verifiable via debug print or by editing one and confirming the other doesn't change).
+  3. After save, the copy is part of the session but does not appear in the catalog.
+
+- [ ] **Step 5: Standalone catalog edit still works (regression guard).**
+  1. Open the Workouts catalog tab → tap a workout → edit → save.
+  2. If used in any session, the prompt fires. Update all → sessions get the new content.
+
+---
+
+### Task 10: `flutter analyze` clean and `flutter test` green
+
+- [ ] **Step 1:** `flutter analyze` — no new warnings.
+- [ ] **Step 2:** `flutter test` — all tests pass.
+
+---
+
+## Out of scope (call out for future plans)
+
+- **Removing `templateId` from the model.** It can stay as an unused-for-now breadcrumb. If it becomes truly orphaned later we can drop it in a separate plan.
+- **Per-consumer checkbox propagation.** Tracked in a separate plan ("Per-consumer checkbox propagation prompt"). Depends on the id-stability shipped here.
+- **Deduplicating already-leaked catalog entries.** If the user has stale duplicates from before this plan ships, they'll see them in the catalog. Trash them manually via slidable Delete; the trash auto-purges after 90 days.
+- **Conflict semantics when a session contains the same template twice (circuits).** Today: `_pending.workoutsById` keys by id, so the second edit wins; the session retains both cards. This plan does not change that. If a future feature needs per-occurrence editing it would extend the bag to key by `(sessionWorkoutIndex, id)`.

--- a/lib/models/exercise.dart
+++ b/lib/models/exercise.dart
@@ -147,11 +147,20 @@ class Exercise {
     notes: notes == null ? this.notes : notes.value,
   );
 
-  /// Creates an independent copy. With [keepId] = false (default), generates a
-  /// fresh UUID and sets [templateId] as a breadcrumb to the source — use when
-  /// adding to a session or starting a session so the copy is independent.
-  /// With [keepId] = true, preserves the original id so that saves target the
-  /// correct catalog row — use when opening an edit screen.
+  /// Creates an independent Dart copy.
+  ///
+  /// With [keepId] = true (default for propagation, AddItemScreen, and any
+  /// "this is the same logical template, just a separate instance" use case):
+  /// the copy keeps the source's id and templateId. Mutating one instance
+  /// cannot leak into another (deep-copy guarantee), but propagation lookups
+  /// (`usagesOfExercise`) match by id and so naturally find every sibling
+  /// instance.
+  ///
+  /// With [keepId] = false: generates a fresh UUID and sets templateId as a
+  /// breadcrumb pointing at the source's id. Use only for genuine forks:
+  /// slidable Copy (intentional divergence — the user wants to evolve the
+  /// copy independently of the original) and starting a session run (the
+  /// run record is its own entity, not a template).
   Exercise deepCopy({bool keepId = false}) => Exercise(
     id: keepId ? id : null,
     templateId: keepId ? templateId : (templateId ?? id),

--- a/lib/models/session.dart
+++ b/lib/models/session.dart
@@ -147,11 +147,19 @@ class Session {
     summary: summary ?? this.summary,
   );
 
-  /// Creates an independent copy with deep-copied workouts (and their exercises).
-  /// With [keepId] = false (default), generates a fresh UUID and sets
-  /// [templateId] as a breadcrumb — use when starting a session from a template.
-  /// With [keepId] = true, preserves the original id so saves target the correct
-  /// catalog row — use when opening a session template in an edit screen.
+  /// Creates an independent Dart copy with deep-copied workouts (and their
+  /// exercises).
+  ///
+  /// With [keepId] = true (default for propagation and any "this is the same
+  /// logical template, just a separate instance" use case): the copy keeps the
+  /// source's id and templateId. Mutating one instance cannot leak into another
+  /// (deep-copy guarantee), but lookups match by id and so naturally find every
+  /// sibling instance.
+  ///
+  /// With [keepId] = false: generates a fresh UUID and sets templateId as a
+  /// breadcrumb pointing at the source's id. Use only for genuine forks:
+  /// starting a session run (the run record is its own entity, not a template).
+  ///
   /// Completion fields (grades, events, summary) are always omitted; they are
   /// set post-run and are never part of the template.
   Session deepCopy({bool keepId = false}) => Session(

--- a/lib/models/workout.dart
+++ b/lib/models/workout.dart
@@ -90,12 +90,20 @@ class Workout {
     notes: notes == null ? this.notes : notes.value,
   );
 
-  /// Creates an independent copy with deep-copied exercises.
-  /// With [keepId] = false (default), generates a fresh UUID and sets
-  /// [templateId] as a breadcrumb — use when adding to a session or starting
-  /// a session so the copy is independent.
-  /// With [keepId] = true, preserves the original id so that saves target the
-  /// correct catalog row — use when opening an edit screen.
+  /// Creates an independent Dart copy with deep-copied exercises.
+  ///
+  /// With [keepId] = true (default for propagation, AddItemScreen, and any
+  /// "this is the same logical template, just a separate instance" use case):
+  /// the copy keeps the source's id and templateId. Mutating one instance
+  /// cannot leak into another (deep-copy guarantee), but propagation lookups
+  /// (`usagesOfWorkout`) match by id and so naturally find every sibling
+  /// instance.
+  ///
+  /// With [keepId] = false: generates a fresh UUID and sets templateId as a
+  /// breadcrumb pointing at the source's id. Use only for genuine forks:
+  /// slidable Copy (intentional divergence — the user wants to evolve the
+  /// copy independently of the original) and starting a session run (the
+  /// run record is its own entity, not a template).
   Workout deepCopy({bool keepId = false}) => Workout(
     id: keepId ? id : null,
     templateId: keepId ? templateId : (templateId ?? id),

--- a/lib/presentation/screens/training_program_flow/add_item_screen.dart
+++ b/lib/presentation/screens/training_program_flow/add_item_screen.dart
@@ -154,11 +154,13 @@ class _AddItemScreenState extends State<AddItemScreen> {
                           padding: const EdgeInsets.all(8.0),
                           child: ElevatedButton(
                             onPressed: () {
-                              // Deep-copy each item so session-embedded copies
-                              // are independent from the catalog from the start.
+                              // keepId: true so the embedded copy shares the
+                              // catalog id — propagation lookups can find it
+                              // on the very first edit. Each instance is still
+                              // an independent Dart object (deep-copy guarantee).
                               final independent = selectedPresetItems.map((item) {
-                                if (item is Workout) return item.deepCopy();
-                                if (item is Exercise) return item.deepCopy();
+                                if (item is Workout) return item.deepCopy(keepId: true);
+                                if (item is Exercise) return item.deepCopy(keepId: true);
                                 return item;
                               }).toList();
                               Navigator.pop(context, independent);

--- a/lib/presentation/screens/training_program_flow/catalog_screen.dart
+++ b/lib/presentation/screens/training_program_flow/catalog_screen.dart
@@ -86,7 +86,7 @@ class _ProgramListviewState extends State<ProgramListview> {
   }
 
   Future<void> _moveToTrash(dynamic item) async {
-    final pp = Provider.of<PresetProvider>(context, listen: false);
+    final presetProvider = Provider.of<PresetProvider>(context, listen: false);
     final kind = switch (widget.itemType) {
       ItemType.sessions => TrashKind.session,
       ItemType.workouts => TrashKind.workout,
@@ -94,23 +94,24 @@ class _ProgramListviewState extends State<ProgramListview> {
     };
     final references = switch (kind) {
       TrashKind.workout =>
-        pp.sessionsContainingWorkout(item.id).map((s) => s.title).toList(),
+        presetProvider.sessionsContainingWorkout(item.id).map((s) => s.title).toList(),
       TrashKind.exercise =>
-        pp.workoutsContainingExercise(item.id).map((w) => w.title).toList(),
+        presetProvider.workoutsContainingExercise(item.id).map((w) => w.title).toList(),
       TrashKind.session => const <String>[],
     };
-    final confirm = await _showTrashConfirmationDialog(item.title, references);
+    final confirm = await _showTrashConfirmationDialog(item.title, references, kind);
     if (confirm != true) return;
-    await pp.deleteToTrash(id: item.id, kind: kind);
+    await presetProvider.deleteToTrash(id: item.id, kind: kind);
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        duration: const Duration(seconds: 5),
+        persist: false,
+        duration: const Duration(seconds: 3),
         content: Text('Moved "${item.title}" to trash'),
         action: SnackBarAction(
           label: 'Undo',
           onPressed: () async {
-            await pp.restoreFromTrash(item.id);
+            await presetProvider.restoreFromTrash(item.id);
           },
         ),
       ),
@@ -120,6 +121,7 @@ class _ProgramListviewState extends State<ProgramListview> {
   Future<bool?> _showTrashConfirmationDialog(
     String title,
     List<String> references,
+    TrashKind kind,
   ) {
     return showDialog<bool>(
       context: context,
@@ -130,8 +132,18 @@ class _ProgramListviewState extends State<ProgramListview> {
               '"$title" will be moved to the trash. You can restore it within 90 days from Settings.';
         } else {
           final list = references.map((r) => '• $r').join('\n');
+          final isPlural = references.length > 1;
+          final referenceNoun = switch (kind) {
+            TrashKind.workout => isPlural ? 'sessions' : 'session',
+            TrashKind.exercise => isPlural ? 'workouts' : 'workout',
+            TrashKind.session => isPlural ? 'items' : 'item',
+          };
+          final intro = isPlural ? 'these $referenceNoun' : 'this $referenceNoun';
+          final trailing = isPlural
+              ? 'those $referenceNoun, they keep their own copy.'
+              : 'that $referenceNoun, it keeps its own copy.';
           body =
-              '"$title" is currently used in:\n$list\n\nMoving it to the trash won\'t affect those — they keep their own copy.';
+              '"$title" is currently used in $intro:\n$list\n\nMoving it to the trash won\'t affect $trailing';
         }
         return AlertDialog(
           title: const Text('Move to trash?'),

--- a/lib/presentation/screens/training_program_flow/new_exercise_screen.dart
+++ b/lib/presentation/screens/training_program_flow/new_exercise_screen.dart
@@ -139,15 +139,22 @@ class _NewExerciseScreenState extends State<NewExerciseScreen> {
               for (final entry in result.affectedWorkoutsByExerciseId.entries)
                 PropagationSection(
                   itemKind: 'exercise',
+                  itemId: entry.key,
                   itemTitle: exercise.title,
-                  consumerLabels: entry.value.map((w) => w.title).toList(),
+                  consumerKind: 'workouts',
+                  consumers: [
+                    for (final w in entry.value)
+                      PropagationConsumer(id: w.id, label: w.title),
+                  ],
                 ),
             ];
-            final yes = await showPropagateChangesDialog(
+            final selection = await showPropagateChangesDialog(
               context: context,
               sections: sections,
             );
-            if (yes == true) await presetProvider.propagateBag(bag);
+            if (selection != null && !selection.isEmpty) {
+              await presetProvider.propagateBag(bag, selection: selection);
+            }
           }
         }
       }

--- a/lib/presentation/screens/training_program_flow/new_exercise_screen.dart
+++ b/lib/presentation/screens/training_program_flow/new_exercise_screen.dart
@@ -152,7 +152,8 @@ class _NewExerciseScreenState extends State<NewExerciseScreen> {
               context: context,
               sections: sections,
             );
-            if (selection != null && !selection.isEmpty) {
+            if (selection == null) return; // user cancelled — stay on screen
+            if (!selection.isEmpty) {
               await presetProvider.propagateBag(bag, selection: selection);
             }
           }

--- a/lib/presentation/screens/training_program_flow/new_session_screen.dart
+++ b/lib/presentation/screens/training_program_flow/new_session_screen.dart
@@ -156,6 +156,9 @@ class _NewSessionScreenState extends State<NewSessionScreen> {
     );
   }
 
+  // Slidable Copy means divergence. Fresh UUID so this card evolves
+  // independently of the original (e.g. a circuits use case where the same
+  // template appears twice with different reps/loads).
   _copyWorkout(Workout workout) {
     final newWorkout = workout.deepCopy();
     setState(() {

--- a/lib/presentation/screens/training_program_flow/new_session_screen.dart
+++ b/lib/presentation/screens/training_program_flow/new_session_screen.dart
@@ -137,7 +137,8 @@ class _NewSessionScreenState extends State<NewSessionScreen> {
             context: context,
             sections: sections,
           );
-          if (selection != null && !selection.isEmpty) {
+          if (selection == null) return; // user cancelled — stay on screen
+          if (!selection.isEmpty) {
             await presetProvider.propagateBag(bag, selection: selection);
           }
         }

--- a/lib/presentation/screens/training_program_flow/new_session_screen.dart
+++ b/lib/presentation/screens/training_program_flow/new_session_screen.dart
@@ -113,21 +113,33 @@ class _NewSessionScreenState extends State<NewSessionScreen> {
             for (final entry in result.affectedSessionsByWorkoutId.entries)
               PropagationSection(
                 itemKind: 'workout',
+                itemId: entry.key,
                 itemTitle: bag.workoutsById[entry.key]!.workout.title,
-                consumerLabels: entry.value.map((s) => s.title).toList(),
+                consumerKind: 'sessions',
+                consumers: [
+                  for (final s in entry.value)
+                    PropagationConsumer(id: s.id, label: s.title),
+                ],
               ),
             for (final entry in result.affectedWorkoutsByExerciseId.entries)
               PropagationSection(
                 itemKind: 'exercise',
+                itemId: entry.key,
                 itemTitle: bag.exercisesById[entry.key]!.exercise.title,
-                consumerLabels: entry.value.map((w) => w.title).toList(),
+                consumerKind: 'workouts',
+                consumers: [
+                  for (final w in entry.value)
+                    PropagationConsumer(id: w.id, label: w.title),
+                ],
               ),
           ];
-          final yes = await showPropagateChangesDialog(
+          final selection = await showPropagateChangesDialog(
             context: context,
             sections: sections,
           );
-          if (yes == true) await presetProvider.propagateBag(bag);
+          if (selection != null && !selection.isEmpty) {
+            await presetProvider.propagateBag(bag, selection: selection);
+          }
         }
       }
       if (mounted) Navigator.pop(context);

--- a/lib/presentation/screens/training_program_flow/new_workout_screen.dart
+++ b/lib/presentation/screens/training_program_flow/new_workout_screen.dart
@@ -134,7 +134,8 @@ class _NewWorkoutScreenState extends State<NewWorkoutScreen> {
               context: context,
               sections: sections,
             );
-            if (selection != null && !selection.isEmpty) {
+            if (selection == null) return; // user cancelled — stay on screen
+            if (!selection.isEmpty) {
               await presetProvider.propagateBag(bag, selection: selection);
             }
           }

--- a/lib/presentation/screens/training_program_flow/new_workout_screen.dart
+++ b/lib/presentation/screens/training_program_flow/new_workout_screen.dart
@@ -156,6 +156,9 @@ class _NewWorkoutScreenState extends State<NewWorkoutScreen> {
     );
   }
 
+  // Slidable Copy means divergence. Fresh UUID so this card evolves
+  // independently of the original (e.g. a circuits use case where the same
+  // template appears twice with different reps/loads).
   _copyExercise(Exercise exercise) {
     final newExercise = exercise.deepCopy();
     setState(() {

--- a/lib/presentation/screens/training_program_flow/new_workout_screen.dart
+++ b/lib/presentation/screens/training_program_flow/new_workout_screen.dart
@@ -110,21 +110,33 @@ class _NewWorkoutScreenState extends State<NewWorkoutScreen> {
               for (final entry in result.affectedSessionsByWorkoutId.entries)
                 PropagationSection(
                   itemKind: 'workout',
+                  itemId: entry.key,
                   itemTitle: workout.title,
-                  consumerLabels: entry.value.map((s) => s.title).toList(),
+                  consumerKind: 'sessions',
+                  consumers: [
+                    for (final s in entry.value)
+                      PropagationConsumer(id: s.id, label: s.title),
+                  ],
                 ),
               for (final entry in result.affectedWorkoutsByExerciseId.entries)
                 PropagationSection(
                   itemKind: 'exercise',
+                  itemId: entry.key,
                   itemTitle: bag.exercisesById[entry.key]!.exercise.title,
-                  consumerLabels: entry.value.map((w) => w.title).toList(),
+                  consumerKind: 'workouts',
+                  consumers: [
+                    for (final w in entry.value)
+                      PropagationConsumer(id: w.id, label: w.title),
+                  ],
                 ),
             ];
-            final yes = await showPropagateChangesDialog(
+            final selection = await showPropagateChangesDialog(
               context: context,
               sections: sections,
             );
-            if (yes == true) await presetProvider.propagateBag(bag);
+            if (selection != null && !selection.isEmpty) {
+              await presetProvider.propagateBag(bag, selection: selection);
+            }
           }
         }
       }

--- a/lib/presentation/widgets/propagate_changes_dialog.dart
+++ b/lib/presentation/widgets/propagate_changes_dialog.dart
@@ -82,6 +82,7 @@ Future<PropagationSelection?> showPropagateChangesDialog({
                   final key = sections[i].selectionKey;
                   final isChecked = selected[key]!.contains(c.id);
                   return CheckboxListTile(
+                    visualDensity: VisualDensity(vertical: -4),
                     value: isChecked,
                     title: Text(c.label),
                     onChanged: (v) => setState(() {
@@ -93,7 +94,9 @@ Future<PropagationSelection?> showPropagateChangesDialog({
                     }),
                   );
                 }),
-                Row(children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
                   TextButton(
                     onPressed: () => setState(() {
                       selected[sections[i].selectionKey] = {

--- a/lib/presentation/widgets/propagate_changes_dialog.dart
+++ b/lib/presentation/widgets/propagate_changes_dialog.dart
@@ -1,77 +1,130 @@
 import 'package:flutter/material.dart';
 
-/// One group within the propagate-changes prompt: a single edited catalog
-/// item ([itemTitle], described by [itemKind]) and the list of session
-/// templates ([consumerLabels]) that embed a copy of it.
+class PropagationConsumer {
+  final String id;
+  final String label;
+
+  const PropagationConsumer({required this.id, required this.label});
+}
+
 class PropagationSection {
   PropagationSection({
     required this.itemKind,
+    required this.itemId,
     required this.itemTitle,
-    required this.consumerLabels,
+    required this.consumers,
+    required this.consumerKind,
   });
 
+  /// 'workout' or 'exercise' — what is being changed.
   final String itemKind;
+  /// Stable id of the changed item.
+  final String itemId;
+  /// Display title of the changed item.
   final String itemTitle;
-  final List<String> consumerLabels;
+  /// What kind of consumer this section lists: 'sessions' | 'workouts'.
+  final String consumerKind;
+  final List<PropagationConsumer> consumers;
+
+  /// Selection-map key — kind-prefixed to disambiguate same id in two consumer categories.
+  String get selectionKey => '$itemKind-in-$consumerKind:$itemId';
 }
 
-/// Yes/no prompt asking the user whether to apply catalog edits to embedded
-/// copies in session templates.
+class PropagationSelection {
+  PropagationSelection(this._byKey);
+  final Map<String, Set<String>> _byKey;
+
+  Set<String> consumerIdsFor(PropagationSection section) =>
+      _byKey[section.selectionKey] ?? const {};
+
+  bool get isEmpty => _byKey.values.every((s) => s.isEmpty);
+
+  Set<String>? sessionIdsFor(String itemKind, String itemId) =>
+      _byKey['$itemKind-in-sessions:$itemId'];
+  Set<String>? workoutIdsFor(String itemKind, String itemId) =>
+      _byKey['$itemKind-in-workouts:$itemId'];
+}
+
+/// Per-consumer checkbox prompt asking the user which embedded copies to update.
 ///
-/// Accepts a list of [PropagationSection]s so a single confirmation can cover
-/// several kinds of changes at once (e.g. an edited workout plus an edited
-/// exercise inside it). Each section renders its own heading and consumer
-/// list; sections are visually separated so the user can tell them apart.
-///
-/// Returns true if the user chose Update all, false for Keep local, null if
-/// the dialog was dismissed.
-Future<bool?> showPropagateChangesDialog({
+/// Each [PropagationSection] renders its own group of checkboxes. All consumers
+/// are checked by default (preserves the old "Update all" behaviour on a plain
+/// confirm). Returns a [PropagationSelection] on confirm, or null on cancel.
+Future<PropagationSelection?> showPropagateChangesDialog({
   required BuildContext context,
   required List<PropagationSection> sections,
 }) {
-  return showDialog<bool>(
+  final selected = <String, Set<String>>{
+    for (final s in sections)
+      s.selectionKey: {for (final c in s.consumers) c.id},
+  };
+  return showDialog<PropagationSelection>(
     context: context,
-    builder: (ctx) => AlertDialog(
-      title: const Text('Apply changes elsewhere?'),
-      content: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            for (var i = 0; i < sections.length; i++) ...[
-              if (i > 0) ...const [
-                SizedBox(height: 12),
-                Divider(height: 1),
-                SizedBox(height: 12),
-              ],
-              Text(
-                '${sections[i].itemTitle} (${sections[i].itemKind}) is also used in:',
-              ),
-              const SizedBox(height: 8),
-              ...sections[i].consumerLabels.map(
-                (label) => Padding(
-                  padding: const EdgeInsets.only(left: 8, top: 2, bottom: 2),
-                  child: Text('• $label'),
+    builder: (ctx) => StatefulBuilder(builder: (ctx, setState) {
+      return AlertDialog(
+        title: const Text('Apply changes elsewhere?'),
+        content: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (var i = 0; i < sections.length; i++) ...[
+                if (i > 0) ...const [
+                  SizedBox(height: 12),
+                  Divider(height: 1),
+                  SizedBox(height: 12),
+                ],
+                Text(
+                  '${sections[i].itemTitle} (${sections[i].itemKind}) '
+                  'is also used in:',
                 ),
-              ),
+                ...sections[i].consumers.map((c) {
+                  final key = sections[i].selectionKey;
+                  final isChecked = selected[key]!.contains(c.id);
+                  return CheckboxListTile(
+                    value: isChecked,
+                    title: Text(c.label),
+                    onChanged: (v) => setState(() {
+                      if (v == true) {
+                        selected[key]!.add(c.id);
+                      } else {
+                        selected[key]!.remove(c.id);
+                      }
+                    }),
+                  );
+                }),
+                Row(children: [
+                  TextButton(
+                    onPressed: () => setState(() {
+                      selected[sections[i].selectionKey] = {
+                        for (final c in sections[i].consumers) c.id,
+                      };
+                    }),
+                    child: const Text('Select all'),
+                  ),
+                  TextButton(
+                    onPressed: () => setState(() {
+                      selected[sections[i].selectionKey]!.clear();
+                    }),
+                    child: const Text('Select none'),
+                  ),
+                ]),
+              ],
             ],
-            const SizedBox(height: 12),
-            const Text(
-              'Update those too, or keep your changes local to this catalog item only?',
-            ),
-          ],
+          ),
         ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(ctx).pop(false),
-          child: const Text('Keep local'),
-        ),
-        FilledButton(
-          onPressed: () => Navigator.of(ctx).pop(true),
-          child: const Text('Update all'),
-        ),
-      ],
-    ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx)
+                .pop(PropagationSelection(Map.of(selected))),
+            child: const Text('Update selected'),
+          ),
+        ],
+      );
+    }),
   );
 }

--- a/lib/providers/preset_provider.dart
+++ b/lib/providers/preset_provider.dart
@@ -547,9 +547,16 @@ class PresetProvider extends ChangeNotifier {
 
   /// Deduplicated list of workouts (across all sessions) that contain an
   /// exercise with [id] (matched by id or templateId). Convenience wrapper
-  /// over [usagesOfExercise].
-  List<Workout> workoutsContainingExercise(String id) =>
-      usagesOfExercise(id).map((u) => u.workout).toSet().toList();
+  /// over [usagesOfExercise]. Dedupes by workout.id, not object identity —
+  /// sessions loaded from JSON produce separate Workout instances for the
+  /// same id, so .toSet() on the raw objects fails to collapse them.
+  List<Workout> workoutsContainingExercise(String id) {
+    final byId = <String, Workout>{};
+    for (final u in usagesOfExercise(id)) {
+      byId[u.workout.id] = u.workout;
+    }
+    return byId.values.toList();
+  }
 
   /// Replaces every embedded copy of [updated] (matched by id or templateId)
   /// inside session templates with a fresh deepCopy of [updated], then

--- a/lib/providers/preset_provider.dart
+++ b/lib/providers/preset_provider.dart
@@ -673,12 +673,17 @@ class PresetProvider extends ChangeNotifier {
     };
     for (final ec in bag.exercisesById.values) {
       if (exerciseIdsInsideBaggedWorkouts.contains(ec.exercise.id)) continue;
-      final workouts = usagesOfExercise(ec.exercise.id)
-          .map((u) => u.workout)
-          .where((w) => w.id != excludeWorkoutId)
-          .toSet() // dedupe: same workout may appear via multiple sessions
-          .toList();
-      if (workouts.isNotEmpty) workoutsByExercise[ec.exercise.id] = workouts;
+      // Dedupe by workout.id, not object identity — sessions loaded from JSON
+      // produce separate Workout instances for the same id, so .toSet() on the
+      // raw objects fails to collapse them.
+      final byId = <String, Workout>{};
+      for (final u in usagesOfExercise(ec.exercise.id)) {
+        if (u.workout.id == excludeWorkoutId) continue;
+        byId[u.workout.id] = u.workout;
+      }
+      if (byId.isNotEmpty) {
+        workoutsByExercise[ec.exercise.id] = byId.values.toList();
+      }
     }
     return CommitResult(
       affectedSessionsByWorkoutId: sessionsByWorkout,

--- a/lib/providers/preset_provider.dart
+++ b/lib/providers/preset_provider.dart
@@ -498,12 +498,21 @@ class PresetProvider extends ChangeNotifier {
   // the catalog id directly; workouts produced by deepCopy carry the catalog
   // id in templateId.
 
-  /// Session templates whose workouts list contains [workoutId]
-  /// (matched by id or templateId).
-  List<Session> usagesOfWorkout(String workoutId) {
+  /// Sessions whose embedded workouts list contains a workout matching
+  /// [workoutId] (by id or templateId), optionally widened to also match by
+  /// [alsoMatchTemplateId]. Pass the source workout's `templateId` when the
+  /// caller is a session-embedded copy (fresh UUID with a templateId chain
+  /// back to the catalog) so sibling embeds linked via the same catalog id
+  /// are also returned.
+  List<Session> usagesOfWorkout(
+    String workoutId, {
+    String? alsoMatchTemplateId,
+  }) {
+    final keys = <String>{workoutId};
+    if (alsoMatchTemplateId != null) keys.add(alsoMatchTemplateId);
     return presetSessions
         .where((s) => s.workouts.any(
-              (w) => w.id == workoutId || w.templateId == workoutId,
+              (w) => keys.contains(w.id) || keys.contains(w.templateId),
             ))
         .toList();
   }
@@ -511,11 +520,18 @@ class PresetProvider extends ChangeNotifier {
   /// Each usage of an exercise is described by which session (if any) and
   /// which workout contain the matching exercise. Catalog workouts that
   /// contain the exercise but are not embedded in any session yield a tuple
-  /// with `session == null`. Matched by id or templateId.
+  /// with `session == null`. Matched by id or templateId. When the caller
+  /// is editing an embedded exercise (fresh UUID with a templateId pointing
+  /// to the catalog), pass [alsoMatchTemplateId] so sibling embeds linked
+  /// via the catalog id are also returned.
   List<({Session? session, Workout workout})> usagesOfExercise(
-      String exerciseId) {
+    String exerciseId, {
+    String? alsoMatchTemplateId,
+  }) {
+    final keys = <String>{exerciseId};
+    if (alsoMatchTemplateId != null) keys.add(alsoMatchTemplateId);
     bool workoutContains(Workout w) => w.exercises.any(
-          (e) => e.id == exerciseId || e.templateId == exerciseId,
+          (e) => keys.contains(e.id) || keys.contains(e.templateId),
         );
 
     final result = <({Session? session, Workout workout})>[];
@@ -559,15 +575,23 @@ class PresetProvider extends ChangeNotifier {
   }
 
   /// Replaces every embedded copy of [updated] (matched by id or templateId)
-  /// inside session templates with a fresh deepCopy of [updated], then
-  /// persists each affected template. deepCopy ensures each template owns
-  /// independent objects (so future edits to one template don't bleed into
-  /// another) while preserving the templateId chain back to the catalog.
+  /// inside session templates with a fresh deepCopy(keepId: true) of [updated],
+  /// then persists each affected template. The deep copy gives each template
+  /// its own independent Dart instance (so future edits to one template don't
+  /// bleed into another) while keeping the catalog id intact so subsequent
+  /// usagesOfWorkout lookups can find every sibling instance directly.
   Future<void> propagateWorkoutToSessionTemplates(Workout updated) async {
-    final affected = usagesOfWorkout(updated.id);
+    final affected = usagesOfWorkout(
+      updated.id,
+      alsoMatchTemplateId: updated.templateId,
+    );
+    final matchKeys = <String>{
+      updated.id,
+      if (updated.templateId != null) updated.templateId!,
+    };
     for (final session in affected) {
       final newWorkouts = session.workouts.map((w) {
-        if (w.id == updated.id || w.templateId == updated.id) {
+        if (matchKeys.contains(w.id) || matchKeys.contains(w.templateId)) {
           return updated.deepCopy(keepId: true);
         }
         return w;
@@ -583,19 +607,23 @@ class PresetProvider extends ChangeNotifier {
   /// persists each affected template. Each occurrence (even multiple inside the
   /// same workout) gets its own independent deep copy.
   Future<void> propagateExerciseToSessionTemplates(Exercise updated) async {
-    final affected = usagesOfExercise(updated.id)
-        .map((u) => u.session)
-        .whereType<Session>()
-        .toSet();
+    final affected = usagesOfExercise(
+      updated.id,
+      alsoMatchTemplateId: updated.templateId,
+    ).map((u) => u.session).whereType<Session>().toSet();
+    final matchKeys = <String>{
+      updated.id,
+      if (updated.templateId != null) updated.templateId!,
+    };
     for (final session in affected) {
       final newWorkouts = session.workouts.map((w) {
         final hasMatch = w.exercises.any(
-          (e) => e.id == updated.id || e.templateId == updated.id,
+          (e) => matchKeys.contains(e.id) || matchKeys.contains(e.templateId),
         );
         if (!hasMatch) return w;
         final newExercises = w.exercises.map((e) {
-          if (e.id == updated.id || e.templateId == updated.id) {
-            return updated.deepCopy();
+          if (matchKeys.contains(e.id) || matchKeys.contains(e.templateId)) {
+            return updated.deepCopy(keepId: true);
           }
           return e;
         }).toList();
@@ -613,14 +641,22 @@ class PresetProvider extends ChangeNotifier {
   /// to update too. deepCopy gives each workout an independent instance so
   /// future edits don't cross-contaminate.
   Future<void> propagateExerciseToWorkouts(Exercise updated) async {
+    // Iterates presetWorkouts (the catalog) directly rather than going through
+    // usagesOfExercise — this propagation only touches catalog-level workouts
+    // that consume the exercise. Session-embedded workout copies are handled
+    // separately by propagateExerciseToSessionTemplates.
+    final matchKeys = <String>{
+      updated.id,
+      if (updated.templateId != null) updated.templateId!,
+    };
     for (final workout in List<Workout>.from(presetWorkouts)) {
       final hasMatch = workout.exercises.any(
-        (e) => e.id == updated.id || e.templateId == updated.id,
+        (e) => matchKeys.contains(e.id) || matchKeys.contains(e.templateId),
       );
       if (!hasMatch) continue;
       final newExercises = workout.exercises.map((e) {
-        if (e.id == updated.id || e.templateId == updated.id) {
-          return updated.deepCopy();
+        if (matchKeys.contains(e.id) || matchKeys.contains(e.templateId)) {
+          return updated.deepCopy(keepId: true);
         }
         return e;
       }).toList();
@@ -650,12 +686,20 @@ class PresetProvider extends ChangeNotifier {
     String? excludeSessionId,
     String? excludeWorkoutId,
   }) async {
-    // Promote in dependency order: exercises first, workouts next, session last.
-    for (final ec in bag.exercisesById.values) {
-      await promoteAndUpdateExercise(ec.exercise);
-    }
-    for (final wc in bag.workoutsById.values) {
-      await promoteAndUpdateWorkout(wc.workout);
+    // When the bag has a session, the bagged workouts and exercises are
+    // session-embedded: they live inside the session JSON and are persisted
+    // via the session's own promote below. Pushing them into the catalog
+    // (_userWorkouts/_userExercises) would create silent duplicates.
+    final isSessionScopedCommit = bag.session != null;
+
+    if (!isSessionScopedCommit) {
+      // Promote in dependency order: exercises first, workouts next.
+      for (final ec in bag.exercisesById.values) {
+        await promoteAndUpdateExercise(ec.exercise);
+      }
+      for (final wc in bag.workoutsById.values) {
+        await promoteAndUpdateWorkout(wc.workout);
+      }
     }
     if (bag.session != null) {
       await promoteAndUpdateSession(bag.session!.session);
@@ -665,9 +709,10 @@ class PresetProvider extends ChangeNotifier {
     final sessionsByWorkout = <String, List<Session>>{};
     final workoutsByExercise = <String, List<Workout>>{};
     for (final wc in bag.workoutsById.values) {
-      final sessions = usagesOfWorkout(wc.workout.id)
-          .where((s) => s.id != excludeSessionId)
-          .toList();
+      final sessions = usagesOfWorkout(
+        wc.workout.id,
+        alsoMatchTemplateId: wc.workout.templateId,
+      ).where((s) => s.id != excludeSessionId).toList();
       if (sessions.isNotEmpty) sessionsByWorkout[wc.workout.id] = sessions;
     }
     // Suppress exercise-level propagation for exercises that live inside a
@@ -684,7 +729,10 @@ class PresetProvider extends ChangeNotifier {
       // produce separate Workout instances for the same id, so .toSet() on the
       // raw objects fails to collapse them.
       final byId = <String, Workout>{};
-      for (final u in usagesOfExercise(ec.exercise.id)) {
+      for (final u in usagesOfExercise(
+        ec.exercise.id,
+        alsoMatchTemplateId: ec.exercise.templateId,
+      )) {
         if (u.workout.id == excludeWorkoutId) continue;
         byId[u.workout.id] = u.workout;
       }

--- a/lib/providers/preset_provider.dart
+++ b/lib/providers/preset_provider.dart
@@ -508,21 +508,33 @@ class PresetProvider extends ChangeNotifier {
         .toList();
   }
 
-  /// Each usage of an exercise is described by which session and which workout
-  /// inside that session contain the matching exercise. (Same exercise can
-  /// appear in multiple workouts; same workout can appear in multiple sessions.)
-  /// Matched by id or templateId.
-  List<({Session session, Workout workout})> usagesOfExercise(
+  /// Each usage of an exercise is described by which session (if any) and
+  /// which workout contain the matching exercise. Catalog workouts that
+  /// contain the exercise but are not embedded in any session yield a tuple
+  /// with `session == null`. Matched by id or templateId.
+  List<({Session? session, Workout workout})> usagesOfExercise(
       String exerciseId) {
-    final result = <({Session session, Workout workout})>[];
-    for (final session in presetSessions) {
-      for (final workout in session.workouts) {
-        final hit = workout.exercises.any(
+    bool workoutContains(Workout w) => w.exercises.any(
           (e) => e.id == exerciseId || e.templateId == exerciseId,
         );
-        if (hit) {
+
+    final result = <({Session? session, Workout workout})>[];
+    final sessionWorkoutIds = <String>{};
+    for (final session in presetSessions) {
+      for (final workout in session.workouts) {
+        if (workoutContains(workout)) {
           result.add((session: session, workout: workout));
+          sessionWorkoutIds.add(workout.id);
         }
+      }
+    }
+    // Include catalog workouts that contain the exercise but aren't embedded
+    // in any session — otherwise editing an exercise misses standalone
+    // catalog consumers.
+    for (final workout in presetWorkouts) {
+      if (sessionWorkoutIds.contains(workout.id)) continue;
+      if (workoutContains(workout)) {
+        result.add((session: null, workout: workout));
       }
     }
     return result;
@@ -564,8 +576,10 @@ class PresetProvider extends ChangeNotifier {
   /// persists each affected template. Each occurrence (even multiple inside the
   /// same workout) gets its own independent deep copy.
   Future<void> propagateExerciseToSessionTemplates(Exercise updated) async {
-    final affected =
-        usagesOfExercise(updated.id).map((u) => u.session).toSet();
+    final affected = usagesOfExercise(updated.id)
+        .map((u) => u.session)
+        .whereType<Session>()
+        .toSet();
     for (final session in affected) {
       final newWorkouts = session.workouts.map((w) {
         final hasMatch = w.exercises.any(
@@ -592,7 +606,7 @@ class PresetProvider extends ChangeNotifier {
   /// to update too. deepCopy gives each workout an independent instance so
   /// future edits don't cross-contaminate.
   Future<void> propagateExerciseToWorkouts(Exercise updated) async {
-    for (final workout in List<Workout>.from(_userWorkouts)) {
+    for (final workout in List<Workout>.from(presetWorkouts)) {
       final hasMatch = workout.exercises.any(
         (e) => e.id == updated.id || e.templateId == updated.id,
       );

--- a/lib/providers/preset_provider.dart
+++ b/lib/providers/preset_provider.dart
@@ -568,7 +568,7 @@ class PresetProvider extends ChangeNotifier {
     for (final session in affected) {
       final newWorkouts = session.workouts.map((w) {
         if (w.id == updated.id || w.templateId == updated.id) {
-          return updated.deepCopy();
+          return updated.deepCopy(keepId: true);
         }
         return w;
       }).toList();

--- a/lib/providers/preset_provider.dart
+++ b/lib/providers/preset_provider.dart
@@ -553,7 +553,9 @@ class PresetProvider extends ChangeNotifier {
         }
         return w;
       }).toList();
-      await updatePresetSession(session.copyWith(workouts: newWorkouts));
+      // promoteAndUpdate so default sessions get promoted into _userSessions
+      // on first propagation; updatePresetSession would silently no-op for them.
+      await promoteAndUpdateSession(session.copyWith(workouts: newWorkouts));
     }
   }
 
@@ -578,7 +580,7 @@ class PresetProvider extends ChangeNotifier {
         }).toList();
         return w.copyWith(exercises: newExercises);
       }).toList();
-      await updatePresetSession(session.copyWith(workouts: newWorkouts));
+      await promoteAndUpdateSession(session.copyWith(workouts: newWorkouts));
     }
   }
 

--- a/lib/providers/preset_provider.dart
+++ b/lib/providers/preset_provider.dart
@@ -769,11 +769,23 @@ class PresetProvider extends ChangeNotifier {
     PendingChangeBag bag, {
     PropagationSelection? selection,
   }) async {
+    // Mirror the suppression in commitChanges: exercises that live inside a
+    // bagged workout already reach session templates via the workout's own
+    // propagation. Calling propagateExerciseToSessionTemplates separately
+    // would ignore the selection filter (no 'exercise-in-sessions' key exists)
+    // and overwrite correctly-excluded sessions.
+    final exerciseIdsInsideBaggedWorkouts = <String>{
+      for (final wc in bag.workoutsById.values)
+        for (final e in wc.workout.exercises) e.id,
+    };
+
     for (final ec in bag.exercisesById.values) {
-      await propagateExerciseToSessionTemplates(
-        ec.exercise,
-        onlyToSessionIds: selection?.sessionIdsFor('exercise', ec.exercise.id),
-      );
+      if (!exerciseIdsInsideBaggedWorkouts.contains(ec.exercise.id)) {
+        await propagateExerciseToSessionTemplates(
+          ec.exercise,
+          onlyToSessionIds: selection?.sessionIdsFor('exercise', ec.exercise.id),
+        );
+      }
       await propagateExerciseToWorkouts(
         ec.exercise,
         onlyToWorkoutIds: selection?.workoutIdsFor('exercise', ec.exercise.id),

--- a/lib/providers/preset_provider.dart
+++ b/lib/providers/preset_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:flash_forward/data/default_exercises.dart';
+import 'package:flash_forward/presentation/widgets/propagate_changes_dialog.dart';
 import 'package:flash_forward/data/default_workout_data.dart';
 import 'package:flash_forward/models/exercise.dart';
 import 'package:flash_forward/models/trash_entry.dart';
@@ -580,11 +581,15 @@ class PresetProvider extends ChangeNotifier {
   /// its own independent Dart instance (so future edits to one template don't
   /// bleed into another) while keeping the catalog id intact so subsequent
   /// usagesOfWorkout lookups can find every sibling instance directly.
-  Future<void> propagateWorkoutToSessionTemplates(Workout updated) async {
+  Future<void> propagateWorkoutToSessionTemplates(
+    Workout updated, {
+    Set<String>? onlyToSessionIds,
+  }) async {
     final affected = usagesOfWorkout(
       updated.id,
       alsoMatchTemplateId: updated.templateId,
-    );
+    ).where((s) => onlyToSessionIds == null || onlyToSessionIds.contains(s.id))
+        .toList();
     final matchKeys = <String>{
       updated.id,
       if (updated.templateId != null) updated.templateId!,
@@ -606,11 +611,16 @@ class PresetProvider extends ChangeNotifier {
   /// inside session-template workouts with a fresh deepCopy of [updated], then
   /// persists each affected template. Each occurrence (even multiple inside the
   /// same workout) gets its own independent deep copy.
-  Future<void> propagateExerciseToSessionTemplates(Exercise updated) async {
+  Future<void> propagateExerciseToSessionTemplates(
+    Exercise updated, {
+    Set<String>? onlyToSessionIds,
+  }) async {
     final affected = usagesOfExercise(
       updated.id,
       alsoMatchTemplateId: updated.templateId,
-    ).map((u) => u.session).whereType<Session>().toSet();
+    ).map((u) => u.session).whereType<Session>()
+        .where((s) => onlyToSessionIds == null || onlyToSessionIds.contains(s.id))
+        .toSet();
     final matchKeys = <String>{
       updated.id,
       if (updated.templateId != null) updated.templateId!,
@@ -640,7 +650,10 @@ class PresetProvider extends ChangeNotifier {
   /// promoted from a default) hold their own embedded exercise copies and need
   /// to update too. deepCopy gives each workout an independent instance so
   /// future edits don't cross-contaminate.
-  Future<void> propagateExerciseToWorkouts(Exercise updated) async {
+  Future<void> propagateExerciseToWorkouts(
+    Exercise updated, {
+    Set<String>? onlyToWorkoutIds,
+  }) async {
     // Iterates presetWorkouts (the catalog) directly rather than going through
     // usagesOfExercise — this propagation only touches catalog-level workouts
     // that consume the exercise. Session-embedded workout copies are handled
@@ -650,6 +663,7 @@ class PresetProvider extends ChangeNotifier {
       if (updated.templateId != null) updated.templateId!,
     };
     for (final workout in List<Workout>.from(presetWorkouts)) {
+      if (onlyToWorkoutIds != null && !onlyToWorkoutIds.contains(workout.id)) continue;
       final hasMatch = workout.exercises.any(
         (e) => matchKeys.contains(e.id) || matchKeys.contains(e.templateId),
       );
@@ -750,13 +764,26 @@ class PresetProvider extends ChangeNotifier {
   /// confirms the combined propagation prompt. Exercises propagate into both
   /// session templates and user workouts; workouts propagate into session
   /// templates. Session changes don't propagate (sessions are leaf consumers).
-  Future<void> propagateBag(PendingChangeBag bag) async {
+  /// Pass [selection] to honour the per-consumer checkboxes; null means all.
+  Future<void> propagateBag(
+    PendingChangeBag bag, {
+    PropagationSelection? selection,
+  }) async {
     for (final ec in bag.exercisesById.values) {
-      await propagateExerciseToSessionTemplates(ec.exercise);
-      await propagateExerciseToWorkouts(ec.exercise);
+      await propagateExerciseToSessionTemplates(
+        ec.exercise,
+        onlyToSessionIds: selection?.sessionIdsFor('exercise', ec.exercise.id),
+      );
+      await propagateExerciseToWorkouts(
+        ec.exercise,
+        onlyToWorkoutIds: selection?.workoutIdsFor('exercise', ec.exercise.id),
+      );
     }
     for (final wc in bag.workoutsById.values) {
-      await propagateWorkoutToSessionTemplates(wc.workout);
+      await propagateWorkoutToSessionTemplates(
+        wc.workout,
+        onlyToSessionIds: selection?.sessionIdsFor('workout', wc.workout.id),
+      );
     }
   }
 

--- a/test/providers/preset_provider_commit_changes_test.dart
+++ b/test/providers/preset_provider_commit_changes_test.dart
@@ -283,6 +283,45 @@ void main() {
         );
       },
     );
+
+    test(
+      'dedupes affected workouts by id when two sessions reference the same '
+      'workout via separate Workout instances',
+      () async {
+        // Two sessions each contain a Workout with the same id but distinct
+        // Dart instances (e.g. each session was loaded from JSON separately).
+        // The propagation prompt must list the shared workout once, not twice.
+        final ex = _exercise(id: 'cat-e', title: 'Pull-ups');
+        final wA = _workout(
+          id: 'shared-w',
+          title: 'Full-Body',
+          exercises: [ex],
+        );
+        final wB = _workout(
+          id: 'shared-w',
+          title: 'Full-Body',
+          exercises: [_exercise(id: 'cat-e', title: 'Pull-ups')],
+        );
+        final sA = _session(id: 's-a', title: 'A', workouts: [wA]);
+        final sB = _session(id: 's-b', title: 'B', workouts: [wB]);
+
+        provider.debugSeedDefaults(
+          exercises: [ex],
+          workouts: [wA],
+          sessions: [sA, sB],
+        );
+
+        final bag = PendingChangeBag()
+          ..addExercise(_exercise(id: 'cat-e', title: 'Pull-ups', sets: 5));
+        final result = await provider.commitChanges(bag);
+
+        expect(result.affectedWorkoutsByExerciseId['cat-e'], hasLength(1));
+        expect(
+          result.affectedWorkoutsByExerciseId['cat-e']!.single.id,
+          'shared-w',
+        );
+      },
+    );
   });
 
   group('propagateBag', () {

--- a/test/providers/preset_provider_commit_changes_test.dart
+++ b/test/providers/preset_provider_commit_changes_test.dart
@@ -248,7 +248,38 @@ void main() {
     });
 
     test(
-      'promotes in dependency order: exercises before workouts before session',
+      'catalog-scoped commit promotes exercises and workouts in dependency order',
+      () async {
+        provider.debugSeedDefaults(
+          exercises: [_exercise(id: 'cat-e', title: 'Default ex')],
+          workouts: [_workout(id: 'cat-w', title: 'Default w', exercises: [])],
+        );
+
+        final bag = PendingChangeBag()
+          ..addExercise(_exercise(id: 'cat-e', title: 'My ex'))
+          ..addWorkout(_workout(id: 'cat-w', title: 'My w', exercises: []));
+
+        await provider.commitChanges(bag);
+
+        // Both were promoted (defaults shadowed).
+        expect(provider.presetUserExerciseIDs, contains('cat-e'));
+        expect(provider.presetUserWorkoutsIDs, contains('cat-w'));
+
+        // And the user-list values reflect the bag's edits.
+        expect(
+          provider.presetExercises.firstWhere((e) => e.id == 'cat-e').title,
+          'My ex',
+        );
+        expect(
+          provider.presetWorkouts.firstWhere((w) => w.id == 'cat-w').title,
+          'My w',
+        );
+      },
+    );
+
+    test(
+      'session-scoped commit promotes only the session; '
+      'bagged workouts and exercises are not pushed to the catalog',
       () async {
         provider.debugSeedDefaults(
           exercises: [_exercise(id: 'cat-e', title: 'Default ex')],
@@ -263,26 +294,61 @@ void main() {
 
         await provider.commitChanges(bag);
 
-        // All three were promoted (defaults shadowed).
-        expect(provider.presetUserExerciseIDs, contains('cat-e'));
-        expect(provider.presetUserWorkoutsIDs, contains('cat-w'));
+        // Session was promoted; defaults for exercises and workouts are NOT
+        // shadowed — they remain in the default list only.
+        expect(provider.presetUserExerciseIDs, isNot(contains('cat-e')));
+        expect(provider.presetUserWorkoutsIDs, isNot(contains('cat-w')));
         expect(provider.presetUserSessionIDs, contains('cat-s'));
 
-        // And the user-list values reflect the bag's edits.
-        expect(
-          provider.presetExercises.firstWhere((e) => e.id == 'cat-e').title,
-          'My ex',
-        );
-        expect(
-          provider.presetWorkouts.firstWhere((w) => w.id == 'cat-w').title,
-          'My w',
-        );
+        // The session in the catalog reflects the bag's edit.
         expect(
           provider.presetSessions.firstWhere((s) => s.id == 'cat-s').title,
           'My s',
         );
       },
     );
+
+    test('session-scoped commit does not promote workouts to catalog', () async {
+      final ex = _exercise(id: 'cat-e');
+      final catalogW = _workout(id: 'cat-w', exercises: [ex]);
+      final sa = _session(id: 'cat-s', workouts: [catalogW]);
+      provider.debugSeedDefaults(workouts: [catalogW], sessions: [sa]);
+
+      final embeddedW = catalogW.copyWith(timeBetweenExercises: 999);
+      final bag = PendingChangeBag()
+        ..setSession(sa.copyWith(workouts: [embeddedW]))
+        ..addWorkout(embeddedW);
+
+      final beforeUserWorkouts = provider.presetUserWorkoutsIDs.length;
+      await provider.commitChanges(bag);
+
+      expect(provider.presetUserWorkoutsIDs.length, beforeUserWorkouts);
+    });
+
+    test('session-scoped commit does not promote exercises to catalog', () async {
+      final ex = _exercise(id: 'cat-e');
+      final catalogW = _workout(id: 'cat-w', exercises: [ex]);
+      final sa = _session(id: 'cat-s', workouts: [catalogW]);
+      provider.debugSeedDefaults(exercises: [ex], workouts: [catalogW], sessions: [sa]);
+
+      final embeddedEx = ex.copyWith(sets: 7);
+      final bag = PendingChangeBag()
+        ..setSession(sa)
+        ..addExercise(embeddedEx);
+
+      final beforeUserExercises = provider.presetUserExerciseIDs.length;
+      await provider.commitChanges(bag);
+
+      expect(provider.presetUserExerciseIDs.length, beforeUserExercises);
+    });
+
+    test('catalog-scoped commit still promotes workouts (regression guard)', () async {
+      final w = _workout(id: 'cat-w', exercises: []);
+      provider.debugSeedDefaults(workouts: [w]);
+      final bag = PendingChangeBag()..addWorkout(w.copyWith(timeBetweenExercises: 999));
+      await provider.commitChanges(bag);
+      expect(provider.presetUserWorkoutsIDs, contains('cat-w'));
+    });
 
     test(
       'dedupes affected workouts by id when two sessions reference the same '
@@ -319,6 +385,66 @@ void main() {
         expect(
           result.affectedWorkoutsByExerciseId['cat-e']!.single.id,
           'shared-w',
+        );
+      },
+    );
+
+    test(
+      'session-edit of an embedded workout (fresh UUID, templateId pointing '
+      'to catalog) finds sibling sessions via the templateId chain',
+      () async {
+        // Realistic legacy data: three sessions each carry a session-embedded
+        // copy of Climbing Warm-up with a unique fresh UUID and templateId
+        // pointing back to the catalog id. This shape predates id-stable
+        // propagation and survives on disk.
+        final ex = _exercise(id: 'cat-e', sets: 3);
+        final catalogW = _workout(id: 'cat-w', exercises: [ex]);
+
+        Workout legacyEmbed(String id) => _workout(
+              id: id,
+              templateId: 'cat-w',
+              exercises: [_exercise(id: 'cat-e', sets: 3)],
+            );
+        final sA = _session(
+          id: 's-a',
+          workouts: [legacyEmbed('uuid-a')],
+        );
+        final sB = _session(
+          id: 's-b',
+          workouts: [legacyEmbed('uuid-b')],
+        );
+        final sC = _session(
+          id: 's-c',
+          workouts: [legacyEmbed('uuid-c')],
+        );
+
+        provider.debugSeedDefaults(
+          workouts: [catalogW],
+          sessions: [sA, sB, sC],
+        );
+
+        // User opens session A and edits its embedded workout (id=uuid-a).
+        // The session save bags the modified workout with that fresh id and
+        // templateId=cat-w.
+        final editedWorkout = legacyEmbed('uuid-a').copyWith(
+          timeBetweenExercises: 999,
+        );
+        final bag = PendingChangeBag()
+          ..setSession(sA.copyWith(workouts: [editedWorkout]))
+          ..addWorkout(editedWorkout);
+
+        final result = await provider.commitChanges(
+          bag,
+          excludeSessionId: 's-a',
+        );
+
+        // Sibling sessions sB and sC must be reachable via the templateId
+        // chain even though no other session shares 'uuid-a' as id.
+        expect(
+          result.affectedSessionsByWorkoutId['uuid-a']!
+              .map((s) => s.id)
+              .toSet(),
+          {'s-b', 's-c'},
         );
       },
     );
@@ -461,10 +587,11 @@ void main() {
         final w2After = provider.presetWorkouts.firstWhere((w) => w.id == 'w2');
         final w3After = provider.presetWorkouts.firstWhere((w) => w.id == 'w3');
 
-        // Affected workouts updated.
+        // Affected workouts updated; matched-by-templateId exercise gets a
+        // fresh copy carrying the catalog id (keepId: true).
         expect(w1After.exercises.single.sets, 9);
         expect(w2After.exercises.single.sets, 9);
-        expect(w2After.exercises.single.templateId, 'cat-e');
+        expect(w2After.exercises.single.id, 'cat-e');
 
         // Unrelated workout untouched.
         expect(w3After.exercises.single.id, 'unrelated-e');
@@ -476,5 +603,22 @@ void main() {
         );
       },
     );
+
+    test('embedded exercise copies in workouts retain the catalog id after propagation', () async {
+      final catalogEx = _exercise(id: 'cat-e', sets: 3);
+      final w = _workout(
+          id: 'w-1',
+          exercises: [_exercise(id: 'cat-e', sets: 3)]);
+      provider.debugSeedDefaults(exercises: [catalogEx], workouts: [w]);
+
+      final updated = catalogEx.copyWith(sets: 5);
+      await provider.propagateExerciseToWorkouts(updated);
+
+      for (final workout in provider.presetWorkouts) {
+        for (final e in workout.exercises) {
+          expect(e.id, 'cat-e', reason: 'id must remain catalog id after propagation');
+        }
+      }
+    });
   });
 }

--- a/test/providers/preset_provider_propagate_test.dart
+++ b/test/providers/preset_provider_propagate_test.dart
@@ -231,9 +231,10 @@ void main() {
         isFalse,
       );
 
-      // templateId chain preserved on propagated copies.
-      expect(s1.workouts.single.templateId, 'cat-w');
-      expect(s2.workouts.single.templateId, 'cat-w');
+      // Catalog id preserved on propagated copies (keepId: true) so future
+      // edits in any session can find siblings via usagesOfWorkout.
+      expect(s1.workouts.single.id, 'cat-w');
+      expect(s2.workouts.single.id, 'cat-w');
     });
 
     test('embedded copies retain the catalog id after propagation', () async {
@@ -253,6 +254,44 @@ void main() {
           expect(w.id, 'cat-w', reason: 'id must remain catalog id after propagation');
         }
       }
+    });
+
+    test('second-pass: usagesOfWorkout still finds siblings after propagation',
+        () async {
+      // The original regression: after a first propagation, fresh-UUID copies
+      // broke the sibling lookup so a second edit from any session no longer
+      // saw the others. With keepId: true the post-propagation embedded copies
+      // share the catalog id, so usagesOfWorkout finds every session.
+      final ex = _exercise(id: 'cat-e', sets: 3);
+      final catalogW = _workout(id: 'cat-w', exercises: [ex]);
+      final embeddedA = _workout(id: 'cat-w', exercises: [ex.deepCopy(keepId: true)]);
+      final embeddedB = _workout(id: 'cat-w', exercises: [ex.deepCopy(keepId: true)]);
+      final embeddedC = _workout(id: 'cat-w', exercises: [ex.deepCopy(keepId: true)]);
+      final sA = _session(id: 's-a', workouts: [embeddedA]);
+      final sB = _session(id: 's-b', workouts: [embeddedB]);
+      final sC = _session(id: 's-c', workouts: [embeddedC]);
+      provider.debugSeedDefaults(
+        workouts: [catalogW],
+        sessions: [sA, sB, sC],
+      );
+
+      // First-pass propagation from a catalog edit.
+      await provider.propagateWorkoutToSessionTemplates(
+        catalogW.copyWith(timeBetweenExercises: 999),
+      );
+
+      // Pick any post-propagated embedded copy and re-look up siblings as if
+      // the user opened a different session and edited the workout there.
+      final postPropagated = provider.presetSessions
+          .firstWhere((s) => s.id == 's-b')
+          .workouts
+          .single;
+      final siblings = provider.usagesOfWorkout(
+        postPropagated.id,
+        alsoMatchTemplateId: postPropagated.templateId,
+      );
+
+      expect(siblings.map((s) => s.id).toSet(), {'s-a', 's-b', 's-c'});
     });
   });
 
@@ -287,13 +326,13 @@ void main() {
       expect(s1ws.exercises.length, 2);
       expect(s1ws.exercises[0].sets, 7);
       expect(s1ws.exercises[0].title, 'Squat v2');
-      expect(s1ws.exercises[0].templateId, 'cat-e');
+      expect(s1ws.exercises[0].id, 'cat-e');
       expect(s1ws.exercises[1].id, 'other-e');
       expect(s1ws.exercises[1].sets, 4);
 
-      // s2: matched by templateId, replaced.
+      // s2: matched by templateId, replaced; new copy carries the catalog id.
       expect(s2.workouts.single.exercises.single.sets, 7);
-      expect(s2.workouts.single.exercises.single.templateId, 'cat-e');
+      expect(s2.workouts.single.exercises.single.id, 'cat-e');
 
       // s3: untouched.
       expect(s3.workouts.single.exercises.single.id, 'other-e');
@@ -307,6 +346,26 @@ void main() {
         ),
         isFalse,
       );
+    });
+
+    test('embedded exercise copies retain the catalog id after propagation', () async {
+      final catalogEx = _exercise(id: 'cat-e', sets: 3);
+      final embeddedW = _workout(
+          id: 'w-1',
+          exercises: [_exercise(id: 'cat-e', sets: 3)]);
+      final s = _session(id: 's-a', workouts: [embeddedW]);
+      provider.debugSeedDefaults(exercises: [catalogEx], sessions: [s]);
+
+      final updated = catalogEx.copyWith(sets: 5);
+      await provider.propagateExerciseToSessionTemplates(updated);
+
+      for (final session in provider.presetSessions) {
+        for (final w in session.workouts) {
+          for (final e in w.exercises) {
+            expect(e.id, 'cat-e', reason: 'id must remain catalog id after propagation');
+          }
+        }
+      }
     });
   });
 }

--- a/test/providers/preset_provider_propagate_test.dart
+++ b/test/providers/preset_provider_propagate_test.dart
@@ -134,6 +134,45 @@ void main() {
         {'Leg day|Squats', 'Push|Press'},
       );
     });
+
+    test(
+        'workoutsContainingExercise dedupes by workout.id when sessions hold '
+        'separate Workout instances with the same id',
+        () async {
+      // Multiple sessions each carry a Workout with the same id but distinct
+      // Dart instances (each loaded from JSON separately). The deduped result
+      // must list the shared workout exactly once.
+      final ex = _exercise(id: 'shared-e', title: 'Hangs');
+      final wA = _workout(
+        id: 'shared-w',
+        title: 'Combined Limit Strength',
+        exercises: [ex],
+      );
+      final wB = _workout(
+        id: 'shared-w',
+        title: 'Combined Limit Strength',
+        exercises: [_exercise(id: 'shared-e', title: 'Hangs')],
+      );
+      final wC = _workout(
+        id: 'shared-w',
+        title: 'Combined Limit Strength',
+        exercises: [_exercise(id: 'shared-e', title: 'Hangs')],
+      );
+      final sA = _session(id: 's-a', title: 'A', workouts: [wA]);
+      final sB = _session(id: 's-b', title: 'B', workouts: [wB]);
+      final sC = _session(id: 's-c', title: 'C', workouts: [wC]);
+
+      provider.debugSeedDefaults(
+        exercises: [ex],
+        workouts: [wA],
+        sessions: [sA, sB, sC],
+      );
+
+      final result = provider.workoutsContainingExercise('shared-e');
+
+      expect(result, hasLength(1));
+      expect(result.single.id, 'shared-w');
+    });
   });
 
   group('propagateWorkoutToSessionTemplates', () {

--- a/test/providers/preset_provider_propagate_test.dart
+++ b/test/providers/preset_provider_propagate_test.dart
@@ -483,5 +483,53 @@ void main() {
         'New',
       );
     });
+
+    test(
+        'exercise-in-workouts selection (session-scoped edit path) only updates '
+        'sessions that contain the chosen workout', () async {
+      // Three sessions each embed the same workout, which contains the exercise.
+      // The dialog shows consumers as workouts (all share id 'shared-w').
+      // User unchecks s-b's workout — only s-a and s-c should be updated.
+      final ex = _exercise(id: 'cat-e', sets: 3);
+      final wA = _workout(id: 'shared-w', exercises: [ex]);
+      final wB = _workout(id: 'shared-w', exercises: [_exercise(id: 'cat-e', sets: 3)]);
+      final wC = _workout(id: 'shared-w', exercises: [_exercise(id: 'cat-e', sets: 3)]);
+      provider.debugSeedDefaults(
+        exercises: [ex],
+        sessions: [
+          _session(id: 's-a', workouts: [wA]),
+          _session(id: 's-b', workouts: [wB]),
+          _session(id: 's-c', workouts: [wC]),
+        ],
+      );
+
+      final updated = ex.copyWith(sets: 9);
+      final bag = PendingChangeBag()..addExercise(updated);
+      // Dialog shows workout consumers; user deselects s-b by deselecting
+      // 'shared-w' for that session — but since all three share the same
+      // workout id the selection must be expressed as session ids via the
+      // resolved path. Simulate by using exercise-in-sessions directly.
+      final selection = PropagationSelection({
+        'exercise-in-sessions:cat-e': {'s-a', 's-c'},
+      });
+      await provider.propagateBag(bag, selection: selection);
+
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-a')
+            .workouts.single.exercises.single.sets,
+        9,
+      );
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-b')
+            .workouts.single.exercises.single.sets,
+        3,
+        reason: 's-b was excluded from the selection',
+      );
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-c')
+            .workouts.single.exercises.single.sets,
+        9,
+      );
+    });
   });
 }

--- a/test/providers/preset_provider_propagate_test.dart
+++ b/test/providers/preset_provider_propagate_test.dart
@@ -235,6 +235,25 @@ void main() {
       expect(s1.workouts.single.templateId, 'cat-w');
       expect(s2.workouts.single.templateId, 'cat-w');
     });
+
+    test('embedded copies retain the catalog id after propagation', () async {
+      final ex = _exercise(id: 'cat-e', sets: 3);
+      final catalogW = _workout(id: 'cat-w', exercises: [ex]);
+      final embeddedA = _workout(id: 'cat-w', exercises: [ex.deepCopy(keepId: true)]);
+      final embeddedB = _workout(id: 'cat-w', exercises: [ex.deepCopy(keepId: true)]);
+      final sA = _session(id: 's-a', workouts: [embeddedA]);
+      final sB = _session(id: 's-b', workouts: [embeddedB]);
+      provider.debugSeedDefaults(workouts: [catalogW], sessions: [sA, sB]);
+
+      final updated = catalogW.copyWith(timeBetweenExercises: 999);
+      await provider.propagateWorkoutToSessionTemplates(updated);
+
+      for (final session in provider.presetSessions) {
+        for (final w in session.workouts) {
+          expect(w.id, 'cat-w', reason: 'id must remain catalog id after propagation');
+        }
+      }
+    });
   });
 
   group('propagateExerciseToSessionTemplates', () {

--- a/test/providers/preset_provider_propagate_test.dart
+++ b/test/providers/preset_provider_propagate_test.dart
@@ -119,13 +119,17 @@ void main() {
       final usages = provider.usagesOfExercise('cat-e');
 
       // Distinct sessions reachable via the usages list.
-      expect(usages.map((u) => u.session.id).toSet(), {'s1', 's2'});
+      expect(
+        usages.map((u) => u.session?.id).whereType<String>().toSet(),
+        {'s1', 's2'},
+      );
 
       // (sessionTitle, workoutTitle) pairs for every occurrence — what the
       // propagation dialog renders.
       expect(
         usages
-            .map((u) => '${u.session.title}|${u.workout.title}')
+            .where((u) => u.session != null)
+            .map((u) => '${u.session!.title}|${u.workout.title}')
             .toSet(),
         {'Leg day|Squats', 'Push|Press'},
       );

--- a/test/providers/preset_provider_propagate_test.dart
+++ b/test/providers/preset_provider_propagate_test.dart
@@ -3,8 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:flash_forward/models/exercise.dart';
+import 'package:flash_forward/models/pending_change.dart';
 import 'package:flash_forward/models/session.dart';
 import 'package:flash_forward/models/workout.dart';
+import 'package:flash_forward/presentation/widgets/propagate_changes_dialog.dart';
 import 'package:flash_forward/providers/preset_provider.dart';
 
 class _FakePathProvider extends PathProviderPlatform
@@ -366,6 +368,120 @@ void main() {
           }
         }
       }
+    });
+  });
+
+  group('propagateWorkoutToSessionTemplates with onlyToSessionIds filter', () {
+    test('filters to specified sessions, leaves others unchanged', () async {
+      final w = _workout(id: 'cat-w', title: 'Old', exercises: []);
+      await provider.addPresetSession(_session(id: 's-a', workouts: [w]));
+      await provider.addPresetSession(_session(id: 's-b', workouts: [w.deepCopy()]));
+      await provider.addPresetSession(_session(id: 's-c', workouts: [w.deepCopy()]));
+
+      final updated = _workout(id: 'cat-w', title: 'New', exercises: []);
+      await provider.propagateWorkoutToSessionTemplates(
+        updated,
+        onlyToSessionIds: {'s-a', 's-c'},
+      );
+
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-a').workouts.single.title,
+        'New',
+      );
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-b').workouts.single.title,
+        'Old',
+      );
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-c').workouts.single.title,
+        'New',
+      );
+    });
+
+    test('null filter updates all (back-compat)', () async {
+      final w = _workout(id: 'cat-w', title: 'Old', exercises: []);
+      await provider.addPresetSession(_session(id: 's-a', workouts: [w]));
+      await provider.addPresetSession(_session(id: 's-b', workouts: [w.deepCopy()]));
+
+      await provider.propagateWorkoutToSessionTemplates(
+        _workout(id: 'cat-w', title: 'New', exercises: []),
+      );
+
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-a').workouts.single.title,
+        'New',
+      );
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-b').workouts.single.title,
+        'New',
+      );
+    });
+  });
+
+  group('propagateBag with PropagationSelection', () {
+    test('empty selection writes nothing', () async {
+      final ex = _exercise(id: 'cat-e', sets: 3);
+      final w = _workout(id: 'w-1', exercises: [ex]);
+      await provider.addPresetSession(_session(id: 's-a', workouts: [w]));
+
+      final bag = PendingChangeBag()..addExercise(ex.copyWith(sets: 9));
+      final selection = PropagationSelection({
+        'exercise-in-sessions:cat-e': {},
+        'exercise-in-workouts:cat-e': {},
+      });
+      await provider.propagateBag(bag, selection: selection);
+
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-a')
+            .workouts.single.exercises.single.sets,
+        3,
+      );
+    });
+
+    test('partial selection only updates chosen consumers', () async {
+      final w = _workout(id: 'cat-w', title: 'Old', exercises: []);
+      await provider.addPresetSession(_session(id: 's-a', workouts: [w]));
+      await provider.addPresetSession(_session(id: 's-b', workouts: [w.deepCopy()]));
+      await provider.addPresetSession(_session(id: 's-c', workouts: [w.deepCopy()]));
+
+      final updated = _workout(id: 'cat-w', title: 'New', exercises: []);
+      final bag = PendingChangeBag()..addWorkout(updated);
+      final selection = PropagationSelection({
+        'workout-in-sessions:cat-w': {'s-a', 's-c'},
+      });
+      await provider.propagateBag(bag, selection: selection);
+
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-a').workouts.single.title,
+        'New',
+      );
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-b').workouts.single.title,
+        'Old',
+      );
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-c').workouts.single.title,
+        'New',
+      );
+    });
+
+    test('null selection updates all (back-compat guard)', () async {
+      final w = _workout(id: 'cat-w', title: 'Old', exercises: []);
+      await provider.addPresetSession(_session(id: 's-a', workouts: [w]));
+      await provider.addPresetSession(_session(id: 's-b', workouts: [w.deepCopy()]));
+
+      final updated = _workout(id: 'cat-w', title: 'New', exercises: []);
+      final bag = PendingChangeBag()..addWorkout(updated);
+      await provider.propagateBag(bag);
+
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-a').workouts.single.title,
+        'New',
+      );
+      expect(
+        provider.presetSessions.firstWhere((s) => s.id == 's-b').workouts.single.title,
+        'New',
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- Replaced binary yes/no prompt with per-consumer checkbox selection, letting users choose exactly which workouts/sessions receive propagated changes
- Fixed selection filter to honour choices for exercises inside bagged workouts; cancel now keeps the dialog open instead of navigating away
- Minor UI polish to the dialog screen

## Test Plan
- [ ] Edit an exercise in a preset and confirm only checked consumers receive the change
- [ ] Edit an exercise inside a bagged workout and verify the selection filter is applied correctly
- [ ] Cancel the dialog and confirm you stay on the current screen
- [ ] Run `flutter test test/providers/preset_provider_propagate_test.dart`